### PR TITLE
Add support for async filter functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
   * `charset`
   * `content_length`
   * `content_type`
+* Add support for async filter functions
 
 ## 0.6.1 (2022-02-13)
 * Migrate to aioredis 2.0

--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -1,5 +1,5 @@
-import pickle
 import inspect
+import pickle
 from abc import ABCMeta, abstractmethod
 from collections import UserDict
 from datetime import datetime
@@ -85,7 +85,11 @@ class CacheBackend:
             'disabled cache': self.disabled,
             'disabled method': str(response.method) not in self.allowed_methods,
             'disabled status': response.status not in self.allowed_codes,
-            'disabled by filter': not (await self.filter_fn(response) if inspect.iscoroutinefunction(self.filter_fn) else self.filter_fn(response)),
+            'disabled by filter': not (
+                await self.filter_fn(response)
+                if inspect.iscoroutinefunction(self.filter_fn)
+                else self.filter_fn(response)
+            ),
             'disabled by headers or expiration params': actions and actions.skip_write,
             'expired': getattr(response, 'is_expired', False),
         }

--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -1,4 +1,5 @@
 import pickle
+import inspect
 from abc import ABCMeta, abstractmethod
 from collections import UserDict
 from datetime import datetime
@@ -73,7 +74,7 @@ class CacheBackend:
         self.include_headers = include_headers
         self.ignored_params = set(ignored_params or [])
 
-    def is_cacheable(
+    async def is_cacheable(
         self, response: Union[AnyResponse, None], actions: CacheActions = None
     ) -> bool:
         """Perform all checks needed to determine if the given response should be cached"""
@@ -84,7 +85,7 @@ class CacheBackend:
             'disabled cache': self.disabled,
             'disabled method': str(response.method) not in self.allowed_methods,
             'disabled status': response.status not in self.allowed_codes,
-            'disabled by filter': not self.filter_fn(response),
+            'disabled by filter': not (await self.filter_fn(response) if inspect.iscoroutinefunction(self.filter_fn) else self.filter_fn(response)),
             'disabled by headers or expiration params': actions and actions.skip_write,
             'expired': getattr(response, 'is_expired', False),
         }
@@ -134,7 +135,7 @@ class CacheBackend:
         if not response:
             logger.debug('No cached response found')
         # If the item is expired or filtered out, delete it from the cache
-        elif not self.is_cacheable(response):  # type: ignore
+        elif not await self.is_cacheable(response):  # type: ignore
             logger.debug('Cached response expired; deleting')
             response = None
             await self.delete(key)

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -53,7 +53,7 @@ class CacheMixin(MIXIN_BASE):
             logger.debug(f'Cached response not found; making request to {str_or_url}')
             new_response = await super()._request(method, str_or_url, **kwargs)  # type: ignore
             actions.update_from_response(new_response)
-            if self.cache.is_cacheable(new_response, actions):
+            if await self.cache.is_cacheable(new_response, actions):
                 await self.cache.save_response(new_response, actions.key, actions.expires)
             return set_response_defaults(new_response)
 

--- a/test/unit/test_base_backend.py
+++ b/test/unit/test_base_backend.py
@@ -230,6 +230,7 @@ async def test_is_cacheable(method, status, disabled, expired, filter_return, ex
     assert await cache.is_cacheable(mock_response) is expected_result
 
 
+@skip_py37
 @pytest.mark.parametrize(
     'method, status, disabled, expired, body, expected_result',
     [

--- a/test/unit/test_base_backend.py
+++ b/test/unit/test_base_backend.py
@@ -1,5 +1,5 @@
-import pickle
 import asyncio
+import pickle
 from sys import version_info
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +26,7 @@ def get_mock_response(**kwargs):
     }
     response_kwargs.update(kwargs)
     return MagicMock(spec=CachedResponse, **response_kwargs)
+
 
 def test_get_placeholder_backend():
     class TestBackend:
@@ -248,12 +249,7 @@ async def test_is_cacheable_inspect(method, status, disabled, expired, body, exp
 
         return json_resp['success']
 
-    mock_response = get_mock_response(
-        method=method,
-        status=status,
-        is_expired=expired,
-        _body=body
-    )
+    mock_response = get_mock_response(method=method, status=status, is_expired=expired, _body=body)
 
     cache = CacheBackend()
     cache.filter_fn = filter

--- a/test/unit/test_base_backend.py
+++ b/test/unit/test_base_backend.py
@@ -1,4 +1,5 @@
 import pickle
+import asyncio
 from sys import version_info
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +26,6 @@ def get_mock_response(**kwargs):
     }
     response_kwargs.update(kwargs)
     return MagicMock(spec=CachedResponse, **response_kwargs)
-
 
 def test_get_placeholder_backend():
     class TestBackend:
@@ -227,4 +227,34 @@ async def test_is_cacheable(method, status, disabled, expired, filter_return, ex
     cache = CacheBackend()
     cache.filter_fn = lambda x: filter_return
     cache.disabled = disabled
-    assert cache.is_cacheable(mock_response) is expected_result
+    assert await cache.is_cacheable(mock_response) is expected_result
+
+
+@pytest.mark.parametrize(
+    'method, status, disabled, expired, body, expected_result',
+    [
+        ('GET', 200, False, False, '{"content": "...", "success": true}', True),
+        ('DELETE', 200, True, False, '{"content": "...", "success": true}', False),
+        ('DELETE', 200, True, False, '{"content": "...", "success": false}', False),
+        ('DELETE', 200, False, False, '{"content": "...", "success": true}', False),
+        ('GET', 200, True, False, '{"content": "...", "success": false}', False),
+        ('GET', 200, False, True, '{"content": "...", "success": true}', False),
+    ],
+)
+async def test_is_cacheable_inspect(method, status, disabled, expired, body, expected_result):
+    async def filter(resp):
+        json_resp = await resp.json()
+
+        return json_resp['success']
+
+    mock_response = get_mock_response(
+        method=method,
+        status=status,
+        is_expired=expired,
+        _body=body
+    )
+
+    cache = CacheBackend()
+    cache.filter_fn = filter
+    cache.disabled = disabled
+    assert await cache.is_cacheable(mock_response) is expected_result

--- a/test/unit/test_base_backend.py
+++ b/test/unit/test_base_backend.py
@@ -1,4 +1,3 @@
-import asyncio
 import pickle
 from sys import version_info
 from unittest.mock import MagicMock, patch

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime, timedelta
 from unittest import mock
 

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 from aiohttp import ClientResponseError, web
 from multidict import MultiDictProxy
-from requests import patch
 from yarl import URL
 
 from aiohttp_client_cache.response import CachedResponse, RequestInfo

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -60,6 +60,7 @@ async def test_basic_attrs(aiohttp_client):
     assert response.history == tuple()
     assert response._released is True
 
+
 @mock.patch('aiohttp_client_cache.response.datetime')
 async def test_is_expired(mock_datetime, aiohttp_client):
     mock_datetime.utcnow = mock.Mock(return_value=datetime.utcnow())


### PR DESCRIPTION
This PR adds support for async filter functions, as described in #121 . Some simple unit tests have been added to check that async filtering works and that the change is backwards compatible.

Unrelated to the core theme of the PR, it also cleaned up a unit test that was timing dependent (expiration test) and failed sometimes based on execution timings. This should now run regardless of actual execution time.

It should be noted that I haven't run any integration tests, but I feel like this shouldn't break much.