### PR TITLE
Reuse SQLite connection objects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       # Cache packages per python version, and reuse until lockfile changes
       - name: Cache python packages
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .venv
           key: venv-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,8 +3,8 @@
 ## 0.8.0 (Unreleased)
 * Lazily initialize and reuse SQLite connection objects
 * Fix `AttributeError` when using a response cached with an older version of `attrs`
-* Add `fast_save` option for SQLite backend (`PRAGMA` setting to improve write performance, with
-  some tradeoffs)
+* Fix concurrent usage of `SQLiteCache.bulk_commit()`
+* Add `fast_save` option for `SQLiteCache` (`PRAGMA` setting to improve write performance, with some tradeoffs)
 
 ## 0.7.3 (2022-07-31)
 * Remove upper version constraint for `attrs` dependency

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # History
 
 ## 0.8.0 (Unreleased)
+* Lazily initialize and reuse SQLite connection objects
 * Fix `AttributeError` when using a response cached with an older version of `attrs`
 * Add `fast_save` option for SQLite backend (`PRAGMA` setting to improve write performance, with
   some tradeoffs)
@@ -12,7 +13,7 @@
 * Fix `TypeError` bug when using `expire_after` param with `CachedSession._request()`
 
 ## 0.7.1 (2022-06-22)
-* Use `threading.RLock` for locking `SQLiteCache.init_db()` and `clear()`
+* Fix possible deadlock with `SQLiteCache.init_db()` and `clear()`
 
 ## 0.7.0 (2022-05-21)
 [See all issues & PRs for v0.7](https://github.com/requests-cache/aiohttp-client-cache/milestone/6?closed=1)

--- a/aiohttp_client_cache/backends/redis.py
+++ b/aiohttp_client_cache/backends/redis.py
@@ -11,7 +11,7 @@ DEFAULT_ADDRESS = 'redis://localhost'
 @extend_init_signature(CacheBackend, redis_template)
 class RedisBackend(CacheBackend):
     """Async cache backend for `Redis <https://redis.io>`_
-    (requires `predis-py <https://redis-py.readthedocs.io>`_)
+    (requires `redis-py <https://redis-py.readthedocs.io>`_)
     """
 
     def __init__(self, cache_name: str = 'aiohttp-cache', address: str = DEFAULT_ADDRESS, **kwargs):

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,6 +4,7 @@
 * All other commands: the current environment will be used instead of creating new ones
 """
 from os.path import join
+from pathlib import Path
 from shutil import rmtree
 
 import nox
@@ -12,20 +13,22 @@ from nox_poetry import session
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = ['lint', 'cov']
 
+DOCS_DIR = Path('docs')
 LIVE_DOCS_PORT = 8181
 LIVE_DOCS_IGNORE = ['*.pyc', '*.tmp', join('**', 'modules', '*')]
 LIVE_DOCS_WATCH = ['aiohttp_client_cache', 'examples']
-CLEAN_DIRS = ['dist', 'build', join('docs', '_build'), join('docs', 'modules')]
+CLEAN_DIRS = ['dist', 'build', DOCS_DIR / '_build', DOCS_DIR / 'modules']
 
-UNIT_TESTS = join('test', 'unit')
-INTEGRATION_TESTS = join('test', 'integration')
+TEST_DIR = Path('test')
+UNIT_TESTS = TEST_DIR / 'unit'
+INTEGRATION_TESTS = TEST_DIR / 'integration'
 COVERAGE_ARGS = (
     '--cov --cov-report=term --cov-report=html'  # Generate HTML + stdout coverage report
 )
 XDIST_ARGS = '--numprocesses=auto --dist=loadfile'  # Run tests in parallel, grouped by test module
 
 
-@session(python=['3.7', '3.8', '3.9', '3.10'])
+@session(python=['3.7', '3.8', '3.9', '3.10', '3.11'])
 def test(session):
     """Run tests for a specific python version"""
     test_paths = session.posargs or [UNIT_TESTS]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
 from os import getenv
+from sys import version_info
 from tempfile import NamedTemporaryFile
 from typing import AsyncIterator
 
@@ -37,12 +38,17 @@ logging.basicConfig(level='INFO')
 # logging.getLogger('aiohttp_client_cache').setLevel('DEBUG')
 
 
+skip_37 = pytest.mark.skipif(
+    version_info < (3, 8), reason='Test requires AsyncMock from python 3.8+'
+)
+
+
 def from_cache(*responses) -> bool:
     """Indicate whether one or more responses came from the cache"""
     return all([isinstance(response, CachedResponse) for response in responses])
 
 
-def httpbin(path):
+def httpbin(path: str = ''):
     """Get the url for either a local or remote httpbin instance"""
     base_url = getenv('HTTPBIN_URL', 'http://localhost:80/')
     return base_url + path

--- a/test/integration/test_filesystem.py
+++ b/test/integration/test_filesystem.py
@@ -2,6 +2,8 @@ from os.path import isfile
 from shutil import rmtree
 from tempfile import gettempdir
 
+import pytest
+
 from aiohttp_client_cache.backends.filesystem import FileBackend, FileCache
 from test.conftest import CACHE_NAME
 from test.integration import BaseBackendTest, BaseStorageTest
@@ -43,3 +45,7 @@ class TestFileCache(BaseStorageTest):
 class TestFileBackend(BaseBackendTest):
     backend_class = FileBackend
     init_kwargs = {'use_temp': True}
+
+    @pytest.mark.skip(reason='Test not yet working for Filesystem backend')
+    async def test_gather(self):
+        super().test_gather()

--- a/test/integration/test_redis.py
+++ b/test/integration/test_redis.py
@@ -1,12 +1,9 @@
 import asyncio
-from contextlib import asynccontextmanager
-from typing import AsyncIterator
 
 import pytest
 from redis.asyncio import from_url
 
 from aiohttp_client_cache.backends.redis import DEFAULT_ADDRESS, RedisBackend, RedisCache
-from aiohttp_client_cache.session import CachedSession
 from test.integration import BaseBackendTest, BaseStorageTest
 
 
@@ -28,10 +25,7 @@ def is_db_running():
 
 pytestmark = [
     pytest.mark.asyncio,
-    pytest.mark.skipif(
-        not is_db_running(),
-        reason='Redis server required for integration tests',
-    ),
+    pytest.mark.skipif(not is_db_running(), reason='Redis server required for integration tests'),
 ]
 
 
@@ -43,8 +37,6 @@ class TestRedisCache(BaseStorageTest):
 class TestRedisBackend(BaseBackendTest):
     backend_class = RedisBackend
 
-    @asynccontextmanager
-    async def init_session(self, **kwargs) -> AsyncIterator[CachedSession]:  # type: ignore
-        async with super().init_session(**kwargs) as session:
-            yield session
-        await session.cache.close()
+    @pytest.mark.skip(reason='Test not yet working for Redis backend')
+    async def test_gather(self):
+        super().test_gather()


### PR DESCRIPTION
Closes #136.

So far, it seems that with `aiosqlite` it's fine to leave an open connection without ever explicitly closing it (same behavior as stdlib `sqlite3`).

There are some differences, though. For example, it manages its own thread for running queries, and its `connect()` function is a layer of abstraction that proxies real `sqlite3` connection objects. So there may be some other potential issues I haven't thought of yet.