### PR TITLE
Improve backend public types

### DIFF
--- a/aiohttp_client_cache/backends/dynamodb.py
+++ b/aiohttp_client_cache/backends/dynamodb.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from typing import AsyncIterable, Dict
+from typing import Any, AsyncIterable, Dict
 
 import aioboto3
 from aioboto3.session import ResourceCreatorContext
@@ -27,7 +27,7 @@ class DynamoDBBackend(CacheBackend):
         val_attr_name: str = 'v',
         create_if_not_exists: bool = False,
         context: ResourceCreatorContext = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         """
         Args:
@@ -74,7 +74,7 @@ class DynamoDbCache(BaseCache):
         val_attr_name: str = 'v',
         create_if_not_exists: bool = False,
         context: ResourceCreatorContext = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.table_name = table_name

--- a/aiohttp_client_cache/backends/filesystem.py
+++ b/aiohttp_client_cache/backends/filesystem.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pickle import PickleError
 from shutil import rmtree
 from tempfile import gettempdir
-from typing import AsyncIterable, Union
+from typing import Any, AsyncIterable, Union
 
 import aiofiles
 import aiofiles.os
@@ -26,7 +26,7 @@ class FileBackend(CacheBackend):
     """
 
     def __init__(
-        self, cache_name: Union[Path, str] = 'http_cache', use_temp: bool = False, **kwargs
+        self, cache_name: Union[Path, str] = 'http_cache', use_temp: bool = False, **kwargs: Any
     ):
         super().__init__(**kwargs)
         self.responses = FileCache(cache_name, use_temp=use_temp, **kwargs)
@@ -37,7 +37,7 @@ class FileBackend(CacheBackend):
 class FileCache(BaseCache):
     """A dictionary-like interface to files on the local filesystem"""
 
-    def __init__(self, cache_name, use_temp: bool = False, **kwargs):
+    def __init__(self, cache_name, use_temp: bool = False, **kwargs: Any):
         super().__init__(**kwargs)
         self.cache_dir = _get_cache_dir(cache_name, use_temp)
 
@@ -46,7 +46,7 @@ class FileCache(BaseCache):
         """Attempt an I/O operation, and either ignore errors or re-raise them as KeyErrors"""
         try:
             yield
-        except (IOError, OSError, PickleError):
+        except (OSError, PickleError):
             if not ignore_errors:
                 raise
 

--- a/aiohttp_client_cache/backends/mongodb.py
+++ b/aiohttp_client_cache/backends/mongodb.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterable
+from typing import Any, AsyncIterable
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
@@ -13,7 +13,10 @@ class MongoDBBackend(CacheBackend):
     """
 
     def __init__(
-        self, cache_name: str = 'aiohttp-cache', connection: AsyncIOMotorClient = None, **kwargs
+        self,
+        cache_name: str = 'aiohttp-cache',
+        connection: AsyncIOMotorClient = None,
+        **kwargs: Any
     ):
         """
         Args:
@@ -36,7 +39,11 @@ class MongoDBCache(BaseCache):
     """
 
     def __init__(
-        self, db_name: str, collection_name: str, connection: AsyncIOMotorClient = None, **kwargs
+        self,
+        db_name: str,
+        collection_name: str,
+        connection: AsyncIOMotorClient = None,
+        **kwargs: Any
     ):
         super().__init__(**kwargs)
         connection_kwargs = get_valid_kwargs(AsyncIOMotorClient.__init__, kwargs)

--- a/aiohttp_client_cache/backends/redis.py
+++ b/aiohttp_client_cache/backends/redis.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterable, Optional
+from typing import Any, AsyncIterable, Optional
 
 from redis.asyncio import Connection, Redis, from_url
 
@@ -14,7 +14,9 @@ class RedisBackend(CacheBackend):
     (requires `redis-py <https://redis-py.readthedocs.io>`_)
     """
 
-    def __init__(self, cache_name: str = 'aiohttp-cache', address: str = DEFAULT_ADDRESS, **kwargs):
+    def __init__(
+        self, cache_name: str = 'aiohttp-cache', address: str = DEFAULT_ADDRESS, **kwargs: Any
+    ):
         """
         Args:
             cache_name: Used as a namespace (prefix for hash key)
@@ -49,7 +51,7 @@ class RedisCache(BaseCache):
         collection_name: str,
         address: str = DEFAULT_ADDRESS,
         connection: Optional[Redis] = None,
-        **kwargs,
+        **kwargs: Any,
     ):
         # Pop off BaseCache kwargs and use the rest as Redis connection kwargs
         super().__init__(**kwargs)

--- a/aiohttp_client_cache/backends/sqlite.py
+++ b/aiohttp_client_cache/backends/sqlite.py
@@ -6,7 +6,7 @@ from os import makedirs
 from os.path import abspath, basename, dirname, expanduser, isabs, join
 from pathlib import Path
 from tempfile import gettempdir
-from typing import AsyncIterable, AsyncIterator, Optional, Union
+from typing import Any, AsyncIterable, AsyncIterator, Optional, Union
 
 import aiosqlite
 
@@ -37,7 +37,7 @@ class SQLiteBackend(CacheBackend):
         cache_name: str = 'aiohttp-cache',
         use_temp: bool = False,
         fast_save: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(cache_name=cache_name, **kwargs)
         self.responses = SQLitePickleCache(
@@ -69,7 +69,7 @@ class SQLiteCache(BaseCache):
         table_name: str = 'aiohttp-cache',
         use_temp: bool = False,
         fast_save: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.connection_kwargs = get_valid_kwargs(sqlite_template, kwargs)


### PR DESCRIPTION
Type checkers expect function params to be fully typed in strict mode. Pyright is particular in also expecting `kwargs` to be annotated.