### PR TITLE
Add autoclose option to close backend when session closes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+
+## 0.8.3 (2023-07-TBD)
+* Add `autoclose` option to `CacheBackend` to close backend connections when the session context exits.
+  * Enabled by default for SQLite backend, and disabled by default for other backends.
+
 ## 0.8.2 (2023-07-14)
 * Add some missing type annotations to backend classes
 * Fix passing connection parameters to MongoDB backend

--- a/aiohttp_client_cache/backends/redis.py
+++ b/aiohttp_client_cache/backends/redis.py
@@ -26,11 +26,6 @@ class RedisBackend(CacheBackend):
         self.responses = RedisCache(cache_name, 'responses', address=address, **kwargs)
         self.redirects = RedisCache(cache_name, 'redirects', address=address, **kwargs)
 
-    async def close(self):
-        """Close any active connections"""
-        await self.responses.close()
-        await self.redirects.close()
-
 
 class RedisCache(BaseCache):
     """An async interface for caching objects in Redis.

--- a/aiohttp_client_cache/backends/sqlite.py
+++ b/aiohttp_client_cache/backends/sqlite.py
@@ -11,12 +11,11 @@ from typing import Any, AsyncIterable, AsyncIterator, Optional, Union
 import aiosqlite
 
 from aiohttp_client_cache.backends import BaseCache, CacheBackend, ResponseOrKey, get_valid_kwargs
-from aiohttp_client_cache.signatures import extend_init_signature, sqlite_template
+from aiohttp_client_cache.signatures import sqlite_template
 
 bulk_commit_var: ContextVar[bool] = ContextVar('bulk_commit', default=False)
 
 
-@extend_init_signature(CacheBackend, sqlite_template)
 class SQLiteBackend(CacheBackend):
     """Async cache backend for `SQLite <https://www.sqlite.org>`_
     (requires `aiosqlite <https://aiosqlite.omnilib.dev>`_)
@@ -37,9 +36,10 @@ class SQLiteBackend(CacheBackend):
         cache_name: str = 'aiohttp-cache',
         use_temp: bool = False,
         fast_save: bool = False,
+        autoclose: bool = True,
         **kwargs: Any,
     ):
-        super().__init__(cache_name=cache_name, **kwargs)
+        super().__init__(cache_name=cache_name, autoclose=autoclose, **kwargs)
         self.responses = SQLitePickleCache(
             cache_name, 'responses', use_temp=use_temp, fast_save=fast_save, **kwargs
         )

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -65,6 +65,7 @@ class CacheMixin(MIXIN_BASE):
     async def close(self):
         """Close both aiohttp connector and any backend connection(s) on contextmanager exit"""
         await super().close()
+        await self.cache.close_if_enabled()
 
     @asynccontextmanager
     async def disabled(self):

--- a/aiohttp_client_cache/signatures.py
+++ b/aiohttp_client_cache/signatures.py
@@ -54,7 +54,9 @@ def extend_init_signature(super_class: Type, *extra_functions: Callable) -> Call
     def wrapper(target_class: Type):
         try:
             # Modify init signature + docstring
-            revision = extend_signature(super_class.__init__, *extra_functions)
+            revision = extend_signature(
+                super_class.__init__, target_class.__init__, *extra_functions
+            )
             target_class.__init__ = revision(target_class.__init__)
             # Include init docs in class docs
             target_class.__doc__ = target_class.__doc__ or ''

--- a/test/integration/test_sqlite.py
+++ b/test/integration/test_sqlite.py
@@ -5,8 +5,9 @@ from unittest.mock import patch
 
 import pytest
 
+from aiohttp_client_cache.backends import CacheBackend
 from aiohttp_client_cache.backends.sqlite import SQLiteBackend, SQLiteCache, SQLitePickleCache
-from test.conftest import CACHE_NAME, skip_37
+from test.conftest import CACHE_NAME, httpbin, skip_37
 from test.integration import BaseBackendTest, BaseStorageTest
 
 pytestmark = pytest.mark.asyncio
@@ -145,3 +146,12 @@ class TestSQLitePickleCache(BaseStorageTest):
 class TestSQLiteBackend(BaseBackendTest):
     backend_class = SQLiteBackend
     init_kwargs = {'use_temp': True}
+
+    @skip_37
+    @patch.object(CacheBackend, 'close')
+    async def test_autoclose__default(self, mock_close):
+        """By default, the backend should be closed when the session is closed"""
+
+        async with self.init_session() as session:
+            await session.get(httpbin('get'))
+        mock_close.assert_called_once()


### PR DESCRIPTION
Closes #153. Also see https://github.com/requests-cache/aiohttp-client-cache/discussions/146

This is enabled by default only for the SQLite backend. 