### PR TITLE
Unit test fixes for FileBackend.

### DIFF
--- a/aiohttp_client_cache/backends/filesystem.py
+++ b/aiohttp_client_cache/backends/filesystem.py
@@ -72,9 +72,13 @@ class FileCache(BaseCache):
         return isfile(self._join(key))
 
     async def read(self, key: str) -> ResponseOrKey:
-        with self._try_io():
-            async with aiofiles.open(self._join(key), 'rb') as f:
-                return self.deserialize(await f.read())
+        with self._try_io(False):
+            path = self._join(key)
+            if await aiofiles.os.path.exists(path):
+                async with aiofiles.open(self._join(key), 'rb') as f:
+                    return self.deserialize(await f.read())
+            else:
+                return None
 
     async def bulk_delete(self, keys: set):
         for key in keys:

--- a/test/integration/test_filesystem.py
+++ b/test/integration/test_filesystem.py
@@ -4,8 +4,6 @@ from shutil import rmtree
 from tempfile import gettempdir
 from typing import AsyncIterator
 
-import pytest
-
 from aiohttp_client_cache.backends.base import BaseCache
 from aiohttp_client_cache.backends.filesystem import FileBackend, FileCache
 from aiohttp_client_cache.session import CachedSession
@@ -51,10 +49,6 @@ class TestFileCache(BaseStorageTest):
 class TestFileBackend(BaseBackendTest):
     backend_class = FileBackend
     init_kwargs = {'use_temp': True}
-
-    @pytest.mark.skip(reason='Test not yet working for Filesystem backend')
-    async def test_gather(self):
-        super().test_gather()
 
     async def test_redirect_cache_path(self):
         async with self.init_session() as session:


### PR DESCRIPTION
This fixes #178 .

In the test_gather method, I added an additional semaphore to limit the maximum number of concurrent requests to 100 as I was getting "too many files open" errors when running the test in my environment (I have maximum number of open files set to 1024). This can be removed as it depends on the environment.

The fix for the test_gather method was to ensure that when opening a nonexistent cache file for a given key, None is returned. Tbh I dont fully understand why this is needed as there the _try_io should catch all exceptions, but apparently something internal to asyncio was not working as expected afterwards.