### PR TITLE
Take disabled status of CachedSession for CacheActions

### DIFF
--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -127,6 +127,7 @@ class CacheBackend:
             session_expire_after=self.expire_after,
             urls_expire_after=self.urls_expire_after,
             cache_control=self.cache_control,
+            cache_disabled=self.disabled,
             **kwargs,
         )
 

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -58,15 +58,19 @@ class CacheActions:
         cls,
         key: str,
         cache_control: bool = False,
+        cache_disabled: bool = False,
         headers: Optional[Mapping] = None,
         **kwargs,
     ):
         """Initialize from request info and CacheBackend settings"""
-        headers = headers or {}
-        if cache_control and has_cache_headers(headers):
-            return cls.from_headers(key, headers)
+        if cache_disabled:
+            return cls(key=key, skip_read=True, skip_write=True, revalidate=True)
         else:
-            return cls.from_settings(key, cache_control=cache_control, **kwargs)
+            headers = headers or {}
+            if cache_control and has_cache_headers(headers):
+                return cls.from_headers(key, headers)
+            else:
+                return cls.from_settings(key, cache_control=cache_control, **kwargs)
 
     @classmethod
     def from_headers(cls, key: str, headers: Mapping):

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -55,7 +55,10 @@ class CacheMixin(MIXIN_BASE):
             return response
         # If the response was missing or expired, send and cache a new request
         else:
-            logger.debug(f'Cached response not found; making request to {str_or_url}')
+            if actions.skip_read:
+                logger.debug(f'Reading from cache was skipped; making request to {str_or_url}')
+            else:
+                logger.debug(f'Cached response not found; making request to {str_or_url}')
             new_response = await super()._request(method, str_or_url, **kwargs)  # type: ignore
             actions.update_from_response(new_response)
             if await self.cache.is_cacheable(new_response, actions):

--- a/test/integration/test_filesystem.py
+++ b/test/integration/test_filesystem.py
@@ -9,7 +9,7 @@ import pytest
 from aiohttp_client_cache.backends.base import BaseCache
 from aiohttp_client_cache.backends.filesystem import FileBackend, FileCache
 from aiohttp_client_cache.session import CachedSession
-from test.conftest import CACHE_NAME, httpbin
+from test.conftest import CACHE_NAME
 from test.integration import BaseBackendTest, BaseStorageTest
 
 
@@ -55,23 +55,6 @@ class TestFileBackend(BaseBackendTest):
     @pytest.mark.skip(reason='Test not yet working for Filesystem backend')
     async def test_gather(self):
         super().test_gather()
-
-    async def test_disabled(self):
-        async with self.init_session() as session:
-            response = await session.request("GET", httpbin('cache/0'))
-
-            assert response.from_cache is False
-            assert await session.cache.responses.size() == 1
-
-            response = await session.request("GET", httpbin('cache/0'))
-
-            assert response.from_cache is True
-            assert await session.cache.responses.size() == 1
-
-            async with session.disabled():
-                response = await session.request("GET", httpbin('cache/0'))
-                assert response.from_cache is False
-                assert await session.cache.responses.size() == 1
 
     async def test_redirect_cache_path(self):
         async with self.init_session() as session:

--- a/test/integration/test_filesystem.py
+++ b/test/integration/test_filesystem.py
@@ -9,7 +9,7 @@ import pytest
 from aiohttp_client_cache.backends.base import BaseCache
 from aiohttp_client_cache.backends.filesystem import FileBackend, FileCache
 from aiohttp_client_cache.session import CachedSession
-from test.conftest import CACHE_NAME
+from test.conftest import CACHE_NAME, httpbin
 from test.integration import BaseBackendTest, BaseStorageTest
 
 
@@ -55,6 +55,23 @@ class TestFileBackend(BaseBackendTest):
     @pytest.mark.skip(reason='Test not yet working for Filesystem backend')
     async def test_gather(self):
         super().test_gather()
+
+    async def test_disabled(self):
+        async with self.init_session() as session:
+            response = await session.request("GET", httpbin('cache/0'))
+
+            assert response.from_cache is False
+            assert await session.cache.responses.size() == 1
+
+            response = await session.request("GET", httpbin('cache/0'))
+
+            assert response.from_cache is True
+            assert await session.cache.responses.size() == 1
+
+            async with session.disabled():
+                response = await session.request("GET", httpbin('cache/0'))
+                assert response.from_cache is False
+                assert await session.cache.responses.size() == 1
 
     async def test_redirect_cache_path(self):
         async with self.init_session() as session:


### PR DESCRIPTION
This fixes #182 .

The proposed fix takes the disabled status of the CachedSession into account when the necessary CacheActions are determined from the request. I tried to follow the existing logic which already includes skip read / write. This could also be solved differently, but I would consider this to be a clean solution.