### PR TITLE
Further unit test fixes

### DIFF
--- a/test/integration/base_storage_test.py
+++ b/test/integration/base_storage_test.py
@@ -83,8 +83,8 @@ class BaseStorageTest:
             for k, v in test_data.items():
                 await cache.write(k, v)
 
-        assert sorted([k async for k in cache.keys()]) == sorted(test_data.keys())
-        assert sorted([v async for v in cache.values()]) == sorted(test_data.values())
+            assert sorted([k async for k in cache.keys()]) == sorted(test_data.keys())
+            assert sorted([v async for v in cache.values()]) == sorted(test_data.values())
 
     async def test_size(self):
         async with self.init_cache() as cache:
@@ -92,7 +92,7 @@ class BaseStorageTest:
             for k, v in self.test_data.items():
                 await cache.write(k, v)
 
-        assert await cache.size() == len(self.test_data)
+            assert await cache.size() == len(self.test_data)
 
     async def test_clear(self):
         async with self.init_cache() as cache:

--- a/test/integration/test_redis.py
+++ b/test/integration/test_redis.py
@@ -36,7 +36,3 @@ class TestRedisCache(BaseStorageTest):
 
 class TestRedisBackend(BaseBackendTest):
     backend_class = RedisBackend
-
-    @pytest.mark.skip(reason='Test not yet working for Redis backend')
-    async def test_gather(self):
-        super().test_gather()


### PR DESCRIPTION
This PR fixes a few further unit test problems that I encountered:

-  gather method for redis backend works fine, so enabled the test
-  ensure files generated during test are created in tmp directory
- ensure that all method calls during test execution happen within a context manager to properly close the cache (otherwise a sqlite connection hangs around in some cases)

With all these fixes, running all tests in my IDE successfully completes without any hanging thread.