### PR TITLE
Support for conditional requests

### DIFF
--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -108,6 +108,7 @@ class CacheBackend:
         method: str,
         url: StrOrURL,
         expire_after: ExpirationTime = None,
+        refresh: bool = False,
         **kwargs,
     ) -> Tuple[Optional[CachedResponse], CacheActions]:
         """Fetch a cached response based on request info
@@ -124,6 +125,7 @@ class CacheBackend:
             key,
             url=url,
             request_expire_after=expire_after,
+            refresh=refresh,
             session_expire_after=self.expire_after,
             urls_expire_after=self.urls_expire_after,
             cache_control=self.cache_control,

--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -118,6 +118,8 @@ class CacheBackend:
             url: Request URL
             expire_after: Expiration time to set only for this request; overrides
                 ``CachedSession.expire_after``, and accepts all the same values.
+            refresh: Revalidate with the server before using a cached response, and refresh if needed
+                (e.g., a "soft refresh", like F5 in a browser)
             kwargs: All other request arguments
         """
         key = self.create_key(method, url, **kwargs)

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -59,18 +59,22 @@ class CacheActions:
         key: str,
         cache_control: bool = False,
         cache_disabled: bool = False,
+        refresh: bool = False,
+        force_refresh: bool = False,
         headers: Optional[Mapping] = None,
         **kwargs,
     ):
         """Initialize from request info and CacheBackend settings"""
         if cache_disabled:
-            return cls(key=key, skip_read=True, skip_write=True, revalidate=True)
+            return cls(key=key, skip_read=True, skip_write=True)
         else:
             headers = headers or {}
             if cache_control and has_cache_headers(headers):
                 return cls.from_headers(key, headers)
             else:
-                return cls.from_settings(key, cache_control=cache_control, **kwargs)
+                return cls.from_settings(
+                    key, cache_control=cache_control, refresh=refresh, **kwargs
+                )
 
     @classmethod
     def from_headers(cls, key: str, headers: Mapping):
@@ -92,6 +96,8 @@ class CacheActions:
         key: str,
         url: StrOrURL,
         cache_control: bool = False,
+        refresh: bool = False,
+        force_refresh: bool = False,
         request_expire_after: ExpirationTime = None,
         session_expire_after: ExpirationTime = None,
         urls_expire_after: Optional[ExpirationPatterns] = None,
@@ -112,7 +118,7 @@ class CacheActions:
             expire_after=expire_after,
             skip_read=do_not_cache,
             skip_write=do_not_cache,
-            revalidate=do_not_cache,
+            revalidate=refresh and not do_not_cache,
         )
 
     @property

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -1,4 +1,6 @@
 """Utilities for determining cache expiration and other cache actions"""
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from fnmatch import fnmatch

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -194,6 +194,25 @@ def has_cache_headers(headers: Mapping) -> bool:
     return any([d in cache_control for d in CACHE_DIRECTIVES] + [bool(headers.get('Expires'))])
 
 
+def get_refresh_headers(
+    request_headers: Optional[Mapping], cached_headers: Mapping
+) -> tuple[bool, Mapping]:
+    """Returns headers containing directives for conditional requests if the cached headers support it.**"""
+    headers = request_headers if request_headers is not None else {}
+    refresh_headers = {k: v for k, v in headers.items()}
+    conditional_request_supported = False
+
+    if "ETag" in cached_headers:
+        refresh_headers["If-None-Match"] = cached_headers["ETag"]
+        conditional_request_supported = True
+
+    if "Last-Modified" in cached_headers:
+        refresh_headers["If-Modified-Since"] = cached_headers["Last-Modified"]
+        conditional_request_supported = True
+
+    return conditional_request_supported, refresh_headers
+
+
 def parse_http_date(value: str) -> Optional[datetime]:
     """Attempt to parse an HTTP (RFC 5322-compatible) timestamp"""
     try:

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -60,7 +60,6 @@ class CacheActions:
         cache_control: bool = False,
         cache_disabled: bool = False,
         refresh: bool = False,
-        force_refresh: bool = False,
         headers: Optional[Mapping] = None,
         **kwargs,
     ):
@@ -87,7 +86,7 @@ class CacheActions:
             expire_after=directives.get('max-age'),
             skip_read=do_not_cache or 'no-store' in directives or 'no-cache' in directives,
             skip_write=do_not_cache or 'no-store' in directives,
-            revalidate=do_not_cache,
+            revalidate=False,
         )
 
     @classmethod
@@ -97,7 +96,6 @@ class CacheActions:
         url: StrOrURL,
         cache_control: bool = False,
         refresh: bool = False,
-        force_refresh: bool = False,
         request_expire_after: ExpirationTime = None,
         session_expire_after: ExpirationTime = None,
         urls_expire_after: Optional[ExpirationPatterns] = None,

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -8,8 +8,8 @@ from aiohttp import ClientSession
 from aiohttp.typedefs import StrOrURL
 
 from aiohttp_client_cache.backends import CacheBackend, get_valid_kwargs
-from aiohttp_client_cache.cache_control import ExpirationTime, get_refresh_headers
-from aiohttp_client_cache.response import AnyResponse, set_response_defaults
+from aiohttp_client_cache.cache_control import CacheActions, ExpirationTime, get_refresh_headers
+from aiohttp_client_cache.response import AnyResponse, CachedResponse, set_response_defaults
 from aiohttp_client_cache.signatures import extend_signature
 
 if TYPE_CHECKING:
@@ -52,44 +52,24 @@ class CacheMixin(MIXIN_BASE):
             method, str_or_url, expire_after=expire_after, refresh=refresh, **kwargs
         )
 
+        def restore_cookies(r):
+            self.cookie_jar.update_cookies(r.cookies or {}, r.url)
+            for redirect in r.history:
+                self.cookie_jar.update_cookies(redirect.cookies or {}, redirect.url)
+
         if actions.revalidate and response:
-            # if the response is present in the cache, try to refresh it from the server
-            conditional_request_supported, refresh_headers = get_refresh_headers(
-                kwargs.get("headers", None), response.headers
+            from_cache, new_response = await self._refresh_cached_response(
+                method, str_or_url, response, actions, **kwargs
             )
-
-            if conditional_request_supported:
-                logger.debug(f'Refreshing cached response; making request to {str_or_url}')
-                refreshed_response = await super()._request(
-                    method, str_or_url, headers=refresh_headers, **kwargs
-                )
-
-                if refreshed_response.status == 304:
-                    logger.debug('Cached response not modified; returning cached response')
-                    pass
-                else:
-                    actions.update_from_response(refreshed_response)
-                    if await self.cache.is_cacheable(refreshed_response, actions):
-                        logger.debug('Cached response refreshed; updating cache')
-                        await self.cache.save_response(
-                            refreshed_response, actions.key, actions.expires
-                        )
-                    else:
-                        logger.debug('Cached response refreshed; deleting from cache')
-                        await self.cache.delete(actions.key)
-
-                    return refreshed_response
+            if not from_cache:
+                return set_response_defaults(new_response)
             else:
-                logger.debug(
-                    'Conditional requests not supported, no ETag or Last-Modified headers present; '
-                    'returning cached response'
-                )
+                restore_cookies(new_response)
+                return new_response
 
         # Restore any cached cookies to the session
         if response:
-            self.cookie_jar.update_cookies(response.cookies or {}, response.url)
-            for redirect in response.history:
-                self.cookie_jar.update_cookies(redirect.cookies or {}, redirect.url)
+            restore_cookies(response)
             return response
         # If the response was missing or expired, send and cache a new request
         else:
@@ -102,6 +82,48 @@ class CacheMixin(MIXIN_BASE):
             if await self.cache.is_cacheable(new_response, actions):
                 await self.cache.save_response(new_response, actions.key, actions.expires)
             return set_response_defaults(new_response)
+
+    async def _refresh_cached_response(
+        self,
+        method: str,
+        str_or_url: StrOrURL,
+        cached_response: CachedResponse,
+        actions: CacheActions,
+        **kwargs,
+    ) -> tuple[bool, AnyResponse]:
+        """Checks if the cached response is still valid using conditional requests if supported"""
+
+        # check whether we can do a conditional request,
+        # i.e. if the necessary headers are present (ETag, Last-Modified)
+        conditional_request_supported, refresh_headers = get_refresh_headers(
+            kwargs.get("headers", None), cached_response.headers
+        )
+
+        if conditional_request_supported:
+            logger.debug(f'Refreshing cached response; making request to {str_or_url}')
+            refreshed_response = await super()._request(
+                method, str_or_url, headers=refresh_headers, **kwargs
+            )
+
+            if refreshed_response.status == 304:
+                logger.debug('Cached response not modified; returning cached response')
+                return True, cached_response
+            else:
+                actions.update_from_response(refreshed_response)
+                if await self.cache.is_cacheable(refreshed_response, actions):
+                    logger.debug('Cached response refreshed; updating cache')
+                    await self.cache.save_response(refreshed_response, actions.key, actions.expires)
+                else:
+                    logger.debug('Cached response refreshed; deleting from cache')
+                    await self.cache.delete(actions.key)
+
+                return False, refreshed_response
+        else:
+            logger.debug(
+                'Conditional requests not supported, no ETag or Last-Modified headers present; '
+                'returning cached response'
+            )
+            return True, cached_response
 
     async def close(self):
         """Close both aiohttp connector and any backend connection(s) on contextmanager exit"""

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -2,7 +2,7 @@
 import warnings
 from contextlib import asynccontextmanager
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from aiohttp import ClientSession
 from aiohttp.typedefs import StrOrURL
@@ -90,7 +90,7 @@ class CacheMixin(MIXIN_BASE):
         cached_response: CachedResponse,
         actions: CacheActions,
         **kwargs,
-    ) -> tuple[bool, AnyResponse]:
+    ) -> Tuple[bool, AnyResponse]:
         """Checks if the cached response is still valid using conditional requests if supported"""
 
         # check whether we can do a conditional request,

--- a/examples/github.py
+++ b/examples/github.py
@@ -4,6 +4,7 @@
 An example of making conditional request to the GitHub Rest API`
 """
 import asyncio
+import logging
 
 from aiohttp_client_cache import CachedSession, FileBackend
 
@@ -22,10 +23,13 @@ async def main():
         print(f"url = {response.url}, status = {response.status}, "
               f"ratelimit-used = {response.headers['x-ratelimit-used']}")
 
+        await asyncio.sleep(1)
+
         response = await session.get(url, refresh=True)
         print(f"url = {response.url}, status = {response.status}, "
               f"ratelimit-used = {response.headers['x-ratelimit-used']}")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     asyncio.run(main())

--- a/examples/github.py
+++ b/examples/github.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# fmt: off
+"""
+An example of making conditional request to the GitHub Rest API`
+"""
+import asyncio
+
+from aiohttp_client_cache import CachedSession, FileBackend
+
+CACHE_DIR = "~/.cache/aiohttp-requests"
+
+
+async def main():
+    cache = FileBackend(cache_name=CACHE_DIR)
+    await cache.clear()
+
+    org = "requests-cache"
+    url = f"https://api.github.com/orgs/{org}/repos"
+
+    async with CachedSession(cache=cache) as session:
+        response = await session.get(url)
+        print(f"url = {response.url}, status = {response.status}, "
+              f"ratelimit-used = {response.headers['x-ratelimit-used']}")
+
+        response = await session.get(url, refresh=True)
+        print(f"url = {response.url}, status = {response.status}, "
+              f"ratelimit-used = {response.headers['x-ratelimit-used']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/github.py
+++ b/examples/github.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # fmt: off
 """
-An example of making conditional request to the GitHub Rest API`
+An example of making conditional requests to the GitHub Rest API`
 """
+
 import asyncio
 import logging
 
@@ -12,12 +13,15 @@ CACHE_DIR = "~/.cache/aiohttp-requests"
 
 
 async def main():
-    cache = FileBackend(cache_name=CACHE_DIR)
+    cache = FileBackend(cache_name=CACHE_DIR, use_temp=True)
     await cache.clear()
 
     org = "requests-cache"
     url = f"https://api.github.com/orgs/{org}/repos"
 
+    # we make 2 requests for the same resource (list of all repos of the requests-cache organization)
+    # the second request refreshes the cached response with the remote server
+    # the debug output should illustrate that the cached response gets refreshed
     async with CachedSession(cache=cache) as session:
         response = await session.get(url)
         print(f"url = {response.url}, status = {response.status}, "
@@ -31,5 +35,6 @@ async def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger("aiohttp_client_cache").setLevel(logging.DEBUG)
     asyncio.run(main())

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -23,7 +23,6 @@ from test.conftest import (
     httpbin,
     skip_37,
 )
-from test.unit.test_base_backend import skip_py37
 
 pytestmark = pytest.mark.asyncio
 
@@ -324,7 +323,7 @@ class BaseBackendTest:
                 assert response.from_cache is False
                 assert await session.cache.responses.size() == 1
 
-    @skip_py37
+    @skip_37
     async def test_conditional_requests(self):
         """Test that conditional requests using refresh=True work.
         The `/cache` endpoint returns proper ETag header and responds to a request

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -4,7 +4,7 @@ import pickle
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, AsyncIterator, Dict, Type
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -23,6 +23,7 @@ from test.conftest import (
     httpbin,
     skip_37,
 )
+from test.unit.test_base_backend import skip_py37
 
 pytestmark = pytest.mark.asyncio
 
@@ -323,6 +324,7 @@ class BaseBackendTest:
                 assert response.from_cache is False
                 assert await session.cache.responses.size() == 1
 
+    @skip_py37
     async def test_conditional_requests(self):
         """Test that conditional requests using refresh=True work.
         The `/cache` endpoint returns proper ETag header and responds to a request
@@ -332,6 +334,8 @@ class BaseBackendTest:
         async with self.init_session() as session:
             # mock the _refresh_cached_response method to verify
             # that a conditional request is being made
+            from unittest.mock import AsyncMock
+
             mock_refresh = AsyncMock(wraps=session._refresh_cached_response)
             session._refresh_cached_response = mock_refresh
 

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -324,7 +324,7 @@ class BaseBackendTest:
                 assert await session.cache.responses.size() == 1
 
     @skip_37
-    async def test_conditional_requests(self):
+    async def test_conditional_request(self):
         """Test that conditional requests using refresh=True work.
         The `/cache` endpoint returns proper ETag header and responds to a request
         with an If-None-Match header with a 304 response.
@@ -343,5 +343,30 @@ class BaseBackendTest:
             mock_refresh.assert_not_awaited()
 
             response = await session.get(httpbin('cache'), refresh=True)
+            assert response.from_cache is True
+            mock_refresh.assert_awaited_once()
+
+    @skip_37
+    async def test_no_support_for_conditional_request(self):
+        """Test that conditional requests using refresh=True work even when the
+        cached response / server does not support conditional requests. In this case
+        the cached response shall be returned as if no refresh=True option would
+        have been passed in.
+        The `/cache/<int>` endpoint returns no ETag header and just returns a normal 200 response.
+        """
+
+        async with self.init_session() as session:
+            # mock the _refresh_cached_response method to verify
+            # that a conditional request is being made
+            from unittest.mock import AsyncMock
+
+            mock_refresh = AsyncMock(wraps=session._refresh_cached_response)
+            session._refresh_cached_response = mock_refresh
+
+            response = await session.get(httpbin('cache/10'))
+            assert response.from_cache is False
+            mock_refresh.assert_not_awaited()
+
+            response = await session.get(httpbin('cache/10'), refresh=True)
             assert response.from_cache is True
             mock_refresh.assert_awaited_once()

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -322,3 +322,16 @@ class BaseBackendTest:
 
                 assert response.from_cache is False
                 assert await session.cache.responses.size() == 1
+
+    async def test_conditional_requests(self):
+        """Test that conditional requests using refresh=True work.
+        The `/cache` endpoint returns proper ETag header and responds to a request
+        with an If-None-Match header with a 304 response.
+        """
+
+        async with self.init_session() as session:
+            # TODO: how do I check that the refresh request really have been made?
+            response = await session.get(httpbin('cache'))
+            assert response.from_cache is False
+            response = await session.get(httpbin('cache'), refresh=True)
+            assert response.from_cache is True


### PR DESCRIPTION
This PR adds support for conditional requests.

I extracted the relevant code in a separate method so that I can check in a test whether it was called with mocking.
However, it would be great if httpbin would support an endpoint to changes its etag over time. Will look into that and provide a patch there so we can use it here as well if accepted.

This fixes #79 .

Code cov needs to be improved though.
