### PR TITLE
Add attribute `closed` to `CachedResponse`

### DIFF
--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -232,7 +232,7 @@ class CachedResponse(HeadersMixin):
 
     async def __aenter__(self) -> 'CachedResponse':
         return self
-    
+
     @property
     def closed(self) -> bool:
         return True

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -232,6 +232,10 @@ class CachedResponse(HeadersMixin):
 
     async def __aenter__(self) -> 'CachedResponse':
         return self
+    
+    @property
+    def closed(self) -> bool:
+        return True
 
     def close(self):
         pass

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -196,6 +196,7 @@ async def test_no_ops(aiohttp_client):
     await response.start()
     response.release()
     response.close()
+    assert response.closed is True
     await response.wait_for_close()
     await response.terminate()
     assert response.connection is None


### PR DESCRIPTION
Add attribute `closed` to `CachedResponse` for compatibility to work with `aiohttp-try`. Fix #191