### PR TITLE
Fix exceptions encountered during tests with python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Fix the 3.11 version due to this regression introduced in 3.11.5:
+        #   https://github.com/python/cpython/issues/109538
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.4']
     services:
       nginx:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.4']
     services:
       nginx:
         image: kennethreitz/httpbin

--- a/aiohttp_client_cache/backends/redis.py
+++ b/aiohttp_client_cache/backends/redis.py
@@ -64,7 +64,7 @@ class RedisCache(BaseCache):
 
     async def close(self):
         if self._connection:
-            await self._connection.close()
+            await self._connection.aclose()
             self._connection = None
 
     async def clear(self):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,3 @@
-import asyncio
-import gc
 import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -82,15 +80,3 @@ def assert_delta_approx_equal(dt1: datetime, dt2: datetime, target_delta, thresh
     """Assert that the given datetimes are approximately ``target_delta`` seconds apart"""
     diff_in_seconds = (dt2 - dt1).total_seconds()
     assert abs(diff_in_seconds - target_delta) <= threshold_seconds
-
-
-# workaround for a regression in python 3.11:
-# https://github.com/python/cpython/issues/109538
-@pytest.fixture
-def event_loop():
-    policy = asyncio.get_event_loop_policy()
-    loop = policy.new_event_loop()
-    loop.set_debug(True)
-    yield loop
-    gc.collect()
-    loop.close()

--- a/test/integration/test_redis.py
+++ b/test/integration/test_redis.py
@@ -13,7 +13,7 @@ def is_db_running():
     async def get_db_info():
         client = await from_url(DEFAULT_ADDRESS)
         await client.info()
-        await client.close()
+        await client.aclose()
 
     try:
         asyncio.run(get_db_info())


### PR DESCRIPTION
There are various exceptions during test execution when run on python 3.11:

![image](https://github.com/requests-cache/aiohttp-client-cache/assets/1048055/33fb4cb2-4921-41d2-a280-d576230da114)

These seems to be related to this issue:

https://github.com/python/cpython/issues/109538

This PR adds the workaround as described in the ticket.