### PR TITLE
fix: use an unprivileged port for a server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       nginx:
         image: kennethreitz/httpbin
         ports:
-          - 80:80
+          - 8080:80
 
     steps:
       - uses: actions/checkout@v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     image: kennethreitz/httpbin
     container_name: httpbin
     ports:
-      - '80:80'
+      # Use an unprivileged port to support running the Docker daemon as a non-root user (Rootless mode).
+      # See https://docs.docker.com/engine/security/rootless/#networking-errors
+      - ${HTTPBIN_CUSTOM_PORT:-8080}:80
 
   httpbin-custom:
     container_name: httpbin-custom

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,7 +50,7 @@ def from_cache(*responses) -> bool:
 
 def httpbin(path: str = ''):
     """Get the url for either a local or remote httpbin instance"""
-    base_url = getenv('HTTPBIN_URL', 'http://localhost:80/')
+    base_url = getenv('HTTPBIN_URL', 'http://localhost:8080/')
     return base_url + path
 
 


### PR DESCRIPTION
## Problem

See https://docs.docker.com/engine/security/rootless/#networking-errors

When running the Docker daemon as a non-root user (Rootless mode), executing `docker compose up` will give an error similar to
```
cannot expose privileged port 80
```

## Solution

There are multiple ways to solve this. All are mentioned in the official Docker docs, see the link above.

On my opinion, the simplest non-breaking solution is to use a non-privileged port by default. 

Additionally, the current solution even extends developer's possibilities: a developer can specify a custom port via `HTTPBIN_CUSTOM_PORT` environment variable before running  `docker compose up`.


## Breaking changes

No.

## Are end-users affected?

No.