### PR TITLE
fix: suppress Mypy error

### DIFF
--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -133,7 +133,7 @@ class CachedResponse(HeadersMixin):
         return True
 
     @property
-    def _headers(self) -> CIMultiDictProxy[str]:
+    def _headers(self) -> CIMultiDictProxy[str]:  # type: ignore[override]
         return self.headers
 
     @property


### PR DESCRIPTION
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

aiohttp_client_cache/response.py:136: error: Cannot override writeable attribute with read-only property  [override]
aiohttp_client_cache/response.py:136: error: Signature of "_headers" incompatible with supertype "HeadersMixin"  [override]
aiohttp_client_cache/response.py:136: note:      Superclass:
aiohttp_client_cache/response.py:136: note:          MultiMapping[str]
aiohttp_client_cache/response.py:136: note:      Subclass:
aiohttp_client_cache/response.py:136: note:          CIMultiDictProxy[str]
Found 2 errors in 1 file (checked 38 source files)
```
Based on the code, I decided that you override a returned type intentionally, so instead of changing a type I suppressed a warning. 