### PR TITLE
Add a DragonflyDB container and related instruction to the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,9 @@ docker-compose up -d
 pytest test/integration
 ```
 
+To test DragonflyDB you need to stop a Redis container (if running) and run `docker compose -f dragonflydb.yaml up`.
+No other changes are required, you can run related tests with e.g. `pytest test -k redis`.
+
 ## Documentation
 [Sphinx](http://www.sphinx-doc.org/en/master/) is used to generate documentation.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # History
 
 ## (Unreleased)
+* Added a Docker Compose file with [DragonflyDB](https://www.dragonflydb.io/) service that can be used as a Redis drop-in replacement.
 * Added minor performance improvements for MongoDB backend. (!203)
 * Drop support for Python 3.7
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ client requests, based on [requests-cache](https://github.com/reclosedev/request
   [expiration](https://aiohttp-client-cache.readthedocs.io/en/stable/user_guide.html#cache-expiration)
   and other [behavior](https://aiohttp-client-cache.readthedocs.io/en/stable/user_guide.html#cache-options)
 * **Persistence:** Includes several [storage backends](https://aiohttp-client-cache.readthedocs.io/en/stable/backends.html):
-  SQLite, DynamoDB, MongoDB, and Redis.
+  SQLite, DynamoDB, MongoDB, DragonflyDB and Redis.
 
 # Quickstart
 First, install with pip (python 3.8+ required):

--- a/dragonflydb.yaml
+++ b/dragonflydb.yaml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  dragonfly:
+    image: 'docker.dragonflydb.io/dragonflydb/dragonfly'
+    #ulimits:
+    #  memlock: -1
+    ports:
+      - "6379:6379"
+    # For better performance, consider `host` mode instead `port` to avoid docker NAT.
+    # `host` mode is NOT currently supported in Swarm Mode.
+    # https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode
+    # network_mode: "host"
+    volumes:
+      - dragonflydata:/data
+volumes:
+  dragonflydata:

--- a/dragonflydb.yaml
+++ b/dragonflydb.yaml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
   dragonfly:
     image: 'docker.dragonflydb.io/dragonflydb/dragonfly'
+    # NOTE: Disabled because this will not work with a rootless Docker.
     #ulimits:
     #  memlock: -1
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 homepage = "https://github.com/requests-cache/aiohttp-client-cache"
 repository = "https://github.com/requests-cache/aiohttp-client-cache"
 keywords = ["aiohttp", "async", "asyncio", "cache", "cache-backends", "client", "http",
-            "persistence", "requests", "sqlite", "redis", "mongodb", "dynamodb"]
+            "persistence", "requests", "sqlite", "redis", "mongodb", "dynamodb", "dragonflydb"]
 include = [
     { path = "*.md", format = "sdist" },
     { path = "*.yml", format = "sdist" },


### PR DESCRIPTION
Currently, I think running DragonflyDB in CI is overkill, unless someone specifically asks for it.