### PR TITLE
chore: migrate outdated Poetry config [ci skip]

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2513,4 +2513,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "21a9031c5e8fdb28f81ea90d7776174a8bd3e72b4c4326cbd3ab0296f037e0dc"
+content-hash = "325156cf77b2e892ba8507583e3fc84b1a41d07d44a533223296b3ab51adf9df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs        = ["furo", "linkify-it-py", "markdown-it-py", "myst-parser", "python
                "sphinx", "sphinx-automodapi","sphinx-autodoc-typehints", "sphinx-copybutton",
                "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 # For unit + integration tests
 async-timeout   = ">=4.0"
 brotli          = ">=1.0"


### PR DESCRIPTION
https://python-poetry.org/docs/managing-dependencies/#dependency-groups

> Poetry will slowly transition away from the dev-dependencies notation which will soon be deprecated, so it’s advised to migrate your existing development dependencies to the new group notation.

You can put this PR on hold if someone still needs to use Poetry 1.2 for some reason, but also if someone has multiple versions installed. 