### PR TITLE
Make `try_int` safer and add a test for it

### DIFF
--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -253,18 +253,29 @@ def try_int(value):
 
 
 @try_int.register
-def _(value: None | int) -> None | int:
+def _(value: None) -> None:
     return value
 
 
 @try_int.register
-def _(value: float | bool) -> NoReturn:
+def _(value: int) -> int:
+    return value
+
+
+@try_int.register
+def _(value: float) -> NoReturn:
     # Make sure that we do not inadvertently process a supertype of `int`.
     raise TypeError
 
 
 @try_int.register
-def _(value: str) -> int | None:
+def _(value: bool) -> NoReturn:
+    # Make sure that we do not inadvertently process a supertype of `int`.
+    raise TypeError
+
+
+@try_int.register
+def _(value: str):
     try:
         return int(value)
     except ValueError:

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from fnmatch import fnmatch
+from functools import singledispatch
 from itertools import chain
 from logging import getLogger
-from typing import Any, Dict, Mapping, Tuple, Union
+from typing import Any, Dict, Mapping, NoReturn, Tuple, Union
 
 from aiohttp import ClientResponse
 from aiohttp.typedefs import StrOrURL
@@ -246,9 +247,28 @@ def to_utc(dt: datetime):
     return dt
 
 
-def try_int(value: str | None) -> int | None:
-    """Convert a string value to an int, if possible, otherwise ``None``"""
-    return int(str(value)) if str(value).isnumeric() else None
+@singledispatch
+def try_int(value):
+    raise NotImplementedError
+
+
+@try_int.register
+def _(value: None | int) -> None | int:
+    return value
+
+
+@try_int.register
+def _(value: float | bool) -> NoReturn:
+    # Make sure that we do not inadvertently process a supertype of `int`.
+    raise TypeError
+
+
+@try_int.register
+def _(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def url_match(url: StrOrURL, pattern: str) -> bool:

--- a/poetry.lock
+++ b/poetry.lock
@@ -720,6 +720,21 @@ files = [
 testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
+name = "faker"
+version = "22.2.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-22.2.0-py3-none-any.whl", hash = "sha256:2c2b7a8e55368defd718226bd5b48ef31b2d082c2900ccb4200987e433be500e"},
+    {file = "Faker-22.2.0.tar.gz", hash = "sha256:fab78f435d27fa7bd109b095eea3504477e4149051c903fd63f11ce252e3d9b7"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+typing-extensions = {version = ">=3.10.0.1", markers = "python_version <= \"3.8\""}
+
+[[package]]
 name = "filelock"
 version = "3.13.1"
 description = "A platform independent file lock."
@@ -1665,7 +1680,7 @@ testing = ["filelock"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-optional = true
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -2513,4 +2528,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "21a9031c5e8fdb28f81ea90d7776174a8bd3e72b4c4326cbd3ab0296f037e0dc"
+content-hash = "8ef8c0c9d56ed1f3f5ff83b3eaac80c59e3b9c43be51cc7725f977a71425bbca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs        = ["furo", "linkify-it-py", "markdown-it-py", "myst-parser", "python
                "sphinx", "sphinx-automodapi","sphinx-autodoc-typehints", "sphinx-copybutton",
                "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.dev-dependencies]
 # For unit + integration tests
 async-timeout   = ">=4.0"
 brotli          = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ exclude_lines = [
 ]
 
 [tool.mypy]
+python_version = 3.8
 ignore_missing_imports = true
 exclude = "dist|build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs        = ["furo", "linkify-it-py", "markdown-it-py", "myst-parser", "python
                "sphinx", "sphinx-automodapi","sphinx-autodoc-typehints", "sphinx-copybutton",
                "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 # For unit + integration tests
 async-timeout   = ">=4.0"
 brotli          = ">=1.0"
@@ -78,6 +78,7 @@ pytest-asyncio  = "^0.14"
 pytest-clarity  = ">=1.0"
 pytest-cov      = "^2.11"
 pytest-xdist    = "^2.3"
+Faker           = "^22.2.0"
 
 # For convenience in local development; additional tools are managed by pre-commit
 nox             = ">=2022.11"

--- a/test/unit/test_cache_control.py
+++ b/test/unit/test_cache_control.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock, patch

--- a/test/unit/test_cache_control.py
+++ b/test/unit/test_cache_control.py
@@ -1,12 +1,22 @@
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
+from contextlib import nullcontext
 
 import pytest
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
+from faker import Faker
 
-from aiohttp_client_cache.cache_control import DO_NOT_CACHE, CacheActions, get_expiration_datetime
+from aiohttp_client_cache.cache_control import (
+    DO_NOT_CACHE,
+    CacheActions,
+    get_expiration_datetime,
+    try_int,
+)
 from test.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
+
+fake = Faker()
 
 IGNORED_DIRECTIVES = [
     'must-revalidate',
@@ -198,3 +208,22 @@ def test_get_expiration_datetime__relative(expire_after, expected_expiration_del
 def test_get_expiration_datetime__httpdate():
     assert get_expiration_datetime(HTTPDATE_STR) == HTTPDATE_DATETIME
     assert get_expiration_datetime('P12Y34M56DT78H90M12.345S') is None
+
+
+@pytest.mark.parametrize(
+    'value, expected_output, error',
+    [
+        (str(random_int := fake.pyint()), random_int, None),  # `str` (numeric) to `int`.
+        ('0', 0, None),  # `str` (numeric) to `int`.
+        (None, None, None),  # `None` to `None`.
+        (random_int, random_int, None),  # `int` to `int`.
+        (fake.pystr(), None, None),  # `str` (non-numeric) to `None`.
+        (fake.pybool(), ..., TypeError),  # Unsupported type.
+        (fake.pyfloat(), ..., TypeError),  # Unsupported type.
+        (fake.pyiterable(), ..., NotImplementedError),  # Unsupported type.
+    ],
+)
+def test_try_int(value: Any, expected_output: str | None, error: type[Exception] | None) -> None:
+    ctx = pytest.raises(error) if error else nullcontext()
+    with ctx:
+        assert try_int(value) == expected_output

--- a/test/unit/test_cache_control.py
+++ b/test/unit/test_cache_control.py
@@ -20,6 +20,9 @@ from test.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
 
 fake = Faker()
 
+# A hack to support pytest-xdist.
+Faker.seed(42)  # Use any value, but it must be the same within a pytest-xdist session.
+
 IGNORED_DIRECTIVES = [
     'must-revalidate',
     'no-transform',


### PR DESCRIPTION
### What

- Now it is clear what is and is not accepted by the function.
- Previously, `float` and `bool` could be silently converted to `None`. Since this is not safe and does not match the function description, `float` and `bool` are now not accepted.
- Added a test. 

### Are there breaking changes? Are users affected?

No.


### Update 1

Sadly, `|` and `typing.Union` are unsupported with `@singledispatch` in older Python versions. I had to downgrade the code and use a much longer syntax.