### PR TITLE
Override __aenter__ for CachedSession

### DIFF
--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -162,3 +162,6 @@ with warnings.catch_warnings():
             cache: A cache backend object. See :py:mod:`aiohttp_client_cache.backends` for
                 options. If not provided, an in-memory cache will be used.
         """
+
+        async def __aenter__(self) -> 'CachedSession':
+            return self


### PR DESCRIPTION
Typechecking complaint about it being ClientSession, so override it to return CachedSession itself.

Or is it intentional to return it as ClientSession?