### PR TITLE
Update Mypy config and type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,10 @@ python_version = 3.8
 ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+warn_unreachable = true
+show_error_codes = true
+show_column_numbers = true
+pretty = true
 exclude = "dist|build"
 
 [tool.ruff]


### PR DESCRIPTION
## Breaking changes

No

## Other notes

I looked at https://github.com/requests-cache/aiohttp-client-cache/commit/e43d75148ce5edcd52356e4985c27d0af855a300 where you added 
```py
        if isinstance(client_response, cls):
            return client_response
```
but I was not able to reproduce why or when these lines can be triggered or used.

### Changelog

I will update in a next PR.

### Next steps

I was going to include `check_untyped_defs = true` in this PR, but it raises too many warnings, so I prefer to create a dedicated PR.