### PR TITLE
Fix/update type annotations

### DIFF
--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import pickle
 from abc import ABCMeta, abstractmethod
@@ -223,7 +225,7 @@ class CacheBackend:
 
         async for key in self.responses.keys():
             response = await self.responses.read(key)
-            if response and response.is_expired or not self.filter_fn(response):
+            if response and response.is_expired or not self.filter_fn(response):  # type: ignore[union-attr,arg-type]
                 keys_to_delete.add(key)
 
         logger.debug(f'Deleting {len(keys_to_delete)} expired cache entries')

--- a/aiohttp_client_cache/backends/dynamodb.py
+++ b/aiohttp_client_cache/backends/dynamodb.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import asynccontextmanager
 from logging import getLogger
 from typing import Any, AsyncIterable, Dict, Optional

--- a/aiohttp_client_cache/backends/dynamodb.py
+++ b/aiohttp_client_cache/backends/dynamodb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from logging import getLogger
-from typing import Any, AsyncIterable, Dict, Optional
+from typing import Any, AsyncIterable
 
 import aioboto3
 from aioboto3.session import ResourceCreatorContext
@@ -43,7 +43,7 @@ class DynamoDBBackend(CacheBackend):
         key_attr_name: str = 'k',
         val_attr_name: str = 'v',
         create_if_not_exists: bool = False,
-        context: Optional[ResourceCreatorContext] = None,
+        context: ResourceCreatorContext | None = None,
         **kwargs: Any,
     ):
         super().__init__(cache_name=cache_name, **kwargs)
@@ -129,10 +129,10 @@ class DynamoDbCache(BaseCache):
 
         return table
 
-    def _doc(self, key) -> Dict:
+    def _doc(self, key) -> dict:
         return {self.key_attr_name: f'{self.namespace}:{key}'}
 
-    async def _scan(self) -> AsyncIterable[Dict]:
+    async def _scan(self) -> AsyncIterable[dict]:
         table = await self.get_table()
         paginator = table.meta.client.get_paginator('scan')
         iterator = paginator.paginate(

--- a/aiohttp_client_cache/backends/filesystem.py
+++ b/aiohttp_client_cache/backends/filesystem.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from os import listdir, makedirs
 from os.path import abspath, expanduser, isabs, isfile, join

--- a/aiohttp_client_cache/backends/filesystem.py
+++ b/aiohttp_client_cache/backends/filesystem.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pickle import PickleError
 from shutil import rmtree
 from tempfile import gettempdir
-from typing import Any, AsyncIterable, Union
+from typing import Any, AsyncIterable
 
 import aiofiles
 import aiofiles.os
@@ -34,7 +34,7 @@ class FileBackend(CacheBackend):
 
     def __init__(
         self,
-        cache_name: Union[Path, str] = 'http_cache',
+        cache_name: Path | str = 'http_cache',
         use_temp: bool = False,
         autoclose: bool = True,
         **kwargs: Any,
@@ -112,7 +112,7 @@ class FileCache(BaseCache):
             yield self._join(key)
 
 
-def _get_cache_dir(cache_dir: Union[Path, str], use_temp: bool) -> str:
+def _get_cache_dir(cache_dir: Path | str, use_temp: bool) -> str:
     # Save to a temp directory, if specified
     if use_temp and not isabs(cache_dir):
         cache_dir = join(gettempdir(), cache_dir, 'responses')

--- a/aiohttp_client_cache/backends/mongodb.py
+++ b/aiohttp_client_cache/backends/mongodb.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, AsyncIterable
 
 from motor.motor_asyncio import AsyncIOMotorClient

--- a/aiohttp_client_cache/backends/redis.py
+++ b/aiohttp_client_cache/backends/redis.py
@@ -1,4 +1,6 @@
-from typing import Any, AsyncIterable, Optional
+from __future__ import annotations
+
+from typing import Any, AsyncIterable
 
 from redis.asyncio import Redis, from_url
 
@@ -46,7 +48,7 @@ class RedisCache(BaseCache):
         namespace: str,
         collection_name: str,
         address: str = DEFAULT_ADDRESS,
-        connection: Optional[Redis] = None,
+        connection: Redis | None = None,
         **kwargs: Any,
     ):
         # Pop off BaseCache kwargs and use the rest as Redis connection kwargs
@@ -64,7 +66,7 @@ class RedisCache(BaseCache):
 
     async def close(self):
         if self._connection:
-            await self._connection.aclose()
+            await self._connection.aclose()  # type: ignore[attr-defined]
             self._connection = None
 
     async def clear(self):

--- a/aiohttp_client_cache/backends/sqlite.py
+++ b/aiohttp_client_cache/backends/sqlite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import sqlite3
 from contextlib import asynccontextmanager
@@ -81,7 +83,7 @@ class SQLiteCache(BaseCache):
         self.filename = _get_cache_filename(filename, use_temp)
         self.table_name = table_name
 
-        self._connection: Optional[aiosqlite.Connection] = None
+        self._connection: aiosqlite.Connection | None = None
         self._lock = asyncio.Lock()
 
     @asynccontextmanager
@@ -97,8 +99,8 @@ class SQLiteCache(BaseCache):
     async def _init_db(self):
         """Initialize the database, if it hasn't already been"""
         if self.fast_save:
-            await self._connection.execute('PRAGMA synchronous = 0;')
-        await self._connection.execute(
+            await self._connection.execute('PRAGMA synchronous = 0;')  # type: ignore[union-attr]
+        await self._connection.execute(  # type: ignore[union-attr]
             f'CREATE TABLE IF NOT EXISTS `{self.table_name}` (key PRIMARY KEY, value)'
         )
         return self._connection
@@ -132,7 +134,7 @@ class SQLiteCache(BaseCache):
         bulk_commit_var.set(True)
         try:
             yield
-            await self._connection.commit()
+            await self._connection.commit()  # type: ignore[union-attr]
         finally:
             bulk_commit_var.set(False)
 
@@ -213,7 +215,7 @@ class SQLitePickleCache(SQLiteCache):
                     yield self.deserialize(row[0])
 
     async def write(self, key, item):
-        await super().write(key, sqlite3.Binary(self.serialize(item)))
+        await super().write(key, sqlite3.Binary(self.serialize(item)))  # type: ignore[arg-type]
 
 
 def sqlite_template(

--- a/aiohttp_client_cache/backends/sqlite.py
+++ b/aiohttp_client_cache/backends/sqlite.py
@@ -8,7 +8,7 @@ from os import makedirs
 from os.path import abspath, basename, dirname, expanduser, isabs, join
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Any, AsyncIterable, AsyncIterator, Optional, Type, Union
+from typing import Any, AsyncIterable, AsyncIterator
 
 import aiosqlite
 
@@ -194,7 +194,7 @@ class SQLiteCache(BaseCache):
                 async for row in cursor:
                     yield row[0]
 
-    async def write(self, key: str, item: Union[ResponseOrKey, sqlite3.Binary]):
+    async def write(self, key: str, item: ResponseOrKey | sqlite3.Binary):
         async with self.get_connection(commit=True) as db:
             await db.execute(
                 f'INSERT OR REPLACE INTO `{self.table_name}` (key,value) VALUES (?,?)',
@@ -221,16 +221,16 @@ class SQLitePickleCache(SQLiteCache):
 def sqlite_template(
     timeout: float = 5.0,
     detect_types: int = 0,
-    isolation_level: Optional[str] = None,
+    isolation_level: str | None = None,
     check_same_thread: bool = True,
-    factory: Optional[Type] = None,
+    factory: type | None = None,
     cached_statements: int = 100,
     uri: bool = False,
 ):
     """Template function to get an accurate function signature for :py:func:`sqlite3.connect`"""
 
 
-def _get_cache_filename(filename: Union[Path, str], use_temp: bool) -> str:
+def _get_cache_filename(filename: Path | str, use_temp: bool) -> str:
     """Get resolved path for database file"""
     # Save to a temp directory, if specified
     if use_temp and not isabs(filename):

--- a/aiohttp_client_cache/cache_keys.py
+++ b/aiohttp_client_cache/cache_keys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping
-from typing import Any, Dict, Iterable, Optional, Sequence, Union
+from typing import Any, Iterable, Sequence, Union
 
 from aiohttp.typedefs import StrOrURL
 from multidict import MultiDict
@@ -16,12 +16,12 @@ RequestParams = Union[Mapping, Sequence, str]
 def create_key(
     method: str,
     url: StrOrURL,
-    params: Optional[RequestParams] = None,
-    data: Optional[Dict] = None,
-    json: Optional[Dict] = None,
-    headers: Optional[Dict] = None,
+    params: RequestParams | None = None,
+    data: dict | None = None,
+    json: dict | None = None,
+    headers: dict | None = None,
     include_headers: bool = False,
-    ignored_params: Optional[Iterable[str]] = None,
+    ignored_params: Iterable[str] | None = None,
     **kwargs,
 ) -> str:
     """Create a unique cache key based on request details"""
@@ -52,7 +52,7 @@ def filter_ignored_params(data, ignored_params: Iterable[str]):
     return MultiDict(((k, v) for k, v in data.items() if k not in ignored_params))
 
 
-def normalize_url_params(url: StrOrURL, params: Optional[RequestParams] = None) -> URL:
+def normalize_url_params(url: StrOrURL, params: RequestParams | None = None) -> URL:
     """Normalize any combination of request parameter formats that aiohttp accepts"""
     if isinstance(url, str):
         url = URL(url)

--- a/aiohttp_client_cache/cache_keys.py
+++ b/aiohttp_client_cache/cache_keys.py
@@ -1,4 +1,6 @@
 """Functions for creating keys used for cache requests"""
+from __future__ import annotations
+
 import hashlib
 from collections.abc import Mapping
 from typing import Any, Dict, Iterable, Optional, Sequence, Union

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -70,7 +70,7 @@ class CachedResponse(HeadersMixin):
     expires: datetime | None = attr.ib(default=None)
     raw_headers: RawHeaders = attr.ib(factory=tuple)
     real_url: StrOrURL = attr.ib(default=None)
-    history: Tuple = attr.ib(factory=tuple)
+    history: tuple = attr.ib(factory=tuple)
     last_used: datetime = attr.ib(factory=datetime.utcnow)
 
     @classmethod

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime
 from http.cookies import SimpleCookie
 from logging import getLogger
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 from unittest.mock import Mock
 from functools import singledispatch
 
@@ -280,16 +280,13 @@ def _(response: CachedResponse) -> CachedResponse:
 
 
 @set_response_defaults.register
-def _(response: ClientResponse) -> CachedResponse:
+def _(response: ClientResponse) -> ClientResponse:
     """Set some default CachedResponse values on a ClientResponse object, so they can be
     expected to always be present
     """
-    # NOTE: We could create a `CachedResponse` instance from a
-    # `ClientResponse` instance, but perhaps it is a little faster
-    # to set a few attributes.
     for k, v in CACHED_RESPONSE_DEFAULTS.items():
         setattr(response, k, v)
-    return cast(CachedResponse, response)
+    return response
 
 
 def _to_str_tuples(data: Mapping) -> DictItems:

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -1,8 +1,10 @@
 """Core functions for cache configuration"""
+from __future__ import annotations
+
 import warnings
 from contextlib import asynccontextmanager
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, cast
 
 from aiohttp import ClientSession
 from aiohttp.typedefs import StrOrURL
@@ -45,7 +47,7 @@ class CacheMixin(MIXIN_BASE):
         expire_after: ExpirationTime = None,
         refresh: bool = False,
         **kwargs,
-    ) -> AnyResponse:
+    ) -> CachedResponse:
         """Wrapper around :py:meth:`.SessionClient._request` that adds caching"""
         # Attempt to fetch cached response
         response, actions = await self.cache.request(
@@ -65,7 +67,7 @@ class CacheMixin(MIXIN_BASE):
                 return set_response_defaults(new_response)
             else:
                 restore_cookies(new_response)
-                return new_response
+                return cast(CachedResponse, new_response)
 
         # Restore any cached cookies to the session
         if response:
@@ -163,5 +165,5 @@ with warnings.catch_warnings():
                 options. If not provided, an in-memory cache will be used.
         """
 
-        async def __aenter__(self) -> 'CachedSession':
+        async def __aenter__(self) -> CachedSession:
             return self

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from contextlib import asynccontextmanager
 from logging import getLogger
-from typing import TYPE_CHECKING, Optional, Tuple, cast
+from typing import TYPE_CHECKING, cast
 
 from aiohttp import ClientSession
 from aiohttp.typedefs import StrOrURL
@@ -28,9 +28,9 @@ class CacheMixin(MIXIN_BASE):
     @extend_signature(ClientSession.__init__)
     def __init__(
         self,
-        base_url: Optional[StrOrURL] = None,
+        base_url: StrOrURL | None = None,
         *,
-        cache: Optional[CacheBackend] = None,
+        cache: CacheBackend | None = None,
         **kwargs,
     ):
         self.cache = cache or CacheBackend()
@@ -92,7 +92,7 @@ class CacheMixin(MIXIN_BASE):
         cached_response: CachedResponse,
         actions: CacheActions,
         **kwargs,
-    ) -> Tuple[bool, AnyResponse]:
+    ) -> tuple[bool, AnyResponse]:
         """Checks if the cached response is still valid using conditional requests if supported"""
 
         # check whether we can do a conditional request,

--- a/aiohttp_client_cache/signatures.py
+++ b/aiohttp_client_cache/signatures.py
@@ -10,6 +10,8 @@ Currently this is used to add the following backend-specific connection details:
 * Type annotations
 * Argument docs
 """
+from __future__ import annotations
+
 import inspect
 import re
 from logging import getLogger

--- a/aiohttp_client_cache/signatures.py
+++ b/aiohttp_client_cache/signatures.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import inspect
 import re
 from logging import getLogger
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable
 
 AUTOMETHOD_INIT = '.. automethod:: __init__'
 logger = getLogger(__name__)
@@ -56,7 +56,7 @@ def get_combined_revision(*functions: Callable):
     return forge.sign(*params.values())
 
 
-def deduplicate_kwargs(params: Dict) -> Dict:
+def deduplicate_kwargs(params: dict) -> dict:
     """If a list of params contains one or more variadic keyword args (e.g., ``**kwargs``),
     ensure there are no duplicates and move it to the end.
     """
@@ -102,7 +102,7 @@ def copy_docstrings(target_function: Callable, *template_functions: Callable) ->
     return target_function
 
 
-def _split_docstring(docstring: Optional[str] = None) -> Tuple[str, str, str]:
+def _split_docstring(docstring: str | None = None) -> tuple[str, str, str]:
     """Split a docstring into the following sections, if present:
 
     * Function summary
@@ -129,7 +129,7 @@ def _combine_args_sections(*args_sections: str) -> str:
     args_section = re.sub('\n\\s+', ' ', args_section)
 
     # Split into key-value pairs to remove any duplicates; if so, keep the first one
-    args: Dict[str, str] = {}
+    args: dict[str, str] = {}
     for line in args_section.splitlines():
         k, v = line.split(':', 1)
         args.setdefault(k.strip(), v.strip())

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,7 @@ def clean(session):
     """Clean up temporary build + documentation files"""
     for dir in CLEAN_DIRS:
         print(f'Removing {dir}')
-        rmtree(dir, ignore_errors=True)
+        rmtree(dir, ignore_errors=True)  # type: ignore[arg-type]
 
 
 @session(python=False, name='cov')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ warn_unused_ignores = true
 warn_unreachable = true
 show_error_codes = true
 show_column_numbers = true
+check_untyped_defs=true
 pretty = true
 exclude = "dist|build"
 

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -1,9 +1,10 @@
 """Common tests to run for all backends"""
+from __future__ import annotations
 import asyncio
 import pickle
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, Type
+from typing import Any, AsyncIterator, Dict, Type, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -13,6 +14,7 @@ from itsdangerous.exc import BadSignature
 from itsdangerous.serializer import Serializer
 
 from aiohttp_client_cache import CacheBackend, CachedSession
+from aiohttp_client_cache.response import CachedResponse
 from test.conftest import (
     ALL_METHODS,
     CACHE_NAME,
@@ -115,18 +117,18 @@ class BaseBackendTest:
             del session
 
             session = await self._init_session(clear=False)
-            r = await session.get(httpbin('get'))
+            r = cast(CachedResponse, await session.get(httpbin('get')))
             assert r.from_cache is True
 
     async def test_request__expire_after(self):
         async with self.init_session() as session:
             await session.get(httpbin('get'), expire_after=1)
-            response = await session.get(httpbin('get'), expire_after=1)
+            response = cast(CachedResponse, await session.get(httpbin('get'), expire_after=1))
             assert response.from_cache is True
 
             # After 1 second, the response should be expired, and a new one should be fetched
             await asyncio.sleep(1)
-            response = await session.get(httpbin('get'), expire_after=1)
+            response = cast(CachedResponse, await session.get(httpbin('get'), expire_after=1))
             print(response.expires)
             assert response.from_cache is False
 
@@ -171,7 +173,7 @@ class BaseBackendTest:
         """Test that streaming requests work both for the original and cached responses"""
         async with self.init_session() as session:
             for _ in range(2):
-                response = await session.get(httpbin('stream-bytes/64'))
+                response = cast(CachedResponse, await session.get(httpbin('stream-bytes/64')))
                 lines = [line async for line in response.content]
                 assert len(b''.join(lines)) == 64
 
@@ -217,19 +219,21 @@ class BaseBackendTest:
             session.cache.cache_control = True
             now = datetime.utcnow()
             await session.get(httpbin('cache/60'), headers=request_headers)
-            response = await session.get(httpbin('cache/60'), headers=request_headers)
+            response = cast(
+                CachedResponse, await session.get(httpbin('cache/60'), headers=request_headers)
+            )
 
         if expected_expiration is None:
             assert response.expires is None
         else:
-            assert_delta_approx_equal(now, response.expires, expected_expiration)
+            assert_delta_approx_equal(now, response.expires, expected_expiration)  # type: ignore[arg-type]
 
     async def test_request__cache_control_disabled(self):
         """By default, no-cache request headers should be ignored"""
         async with self.init_session() as session:
             headers = {'Cache-Control': 'no-cache'}
             await session.get(httpbin('get'), headers=headers)
-            response = await session.get(httpbin('get'), headers=headers)
+            response = cast(CachedResponse, await session.get(httpbin('get'), headers=headers))
             assert response.from_cache is True
 
     async def test_request__skip_cache_read(self):
@@ -239,11 +243,12 @@ class BaseBackendTest:
         async with self.init_session(cache_control=True) as session:
             headers = {'Cache-Control': 'no-cache'}
             await session.get(httpbin('get'), headers=headers)
-            response = await session.get(httpbin('get'), headers=headers)
+            response = cast(CachedResponse, await session.get(httpbin('get'), headers=headers))
 
             assert response.from_cache is False
             assert await session.cache.responses.size() == 1
-            assert (await session.get(httpbin('get'))).from_cache is True
+            response = cast(CachedResponse, await session.get(httpbin('get')))
+            assert response.from_cache is True
 
     @pytest.mark.parametrize('directive', ['max-age=0', 'no-store'])
     async def test_request__skip_cache_read_write(self, directive):
@@ -251,19 +256,19 @@ class BaseBackendTest:
         async with self.init_session(cache_control=True) as session:
             headers = {'Cache-Control': directive}
             await session.get(httpbin('get'), headers=headers)
-            response = await session.get(httpbin('get'), headers=headers)
+            response = cast(CachedResponse, await session.get(httpbin('get'), headers=headers))
 
             assert response.from_cache is False
             assert await session.cache.responses.size() == 0
 
             await session.get(httpbin('get'))
-            assert (await session.get(httpbin('get'))).from_cache is True
+            assert (cast(CachedResponse, await session.get(httpbin('get')))).from_cache is True
 
     async def test_response__skip_cache_write(self):
         """max-age=0 response header should skip writing to the cache"""
         async with self.init_session(cache_control=True) as session:
             await session.get(httpbin('cache/0'))
-            response = await session.get(httpbin('cache/0'))
+            response = cast(CachedResponse, await session.get(httpbin('cache/0')))
 
             assert response.from_cache is False
             assert await session.cache.responses.size() == 0
@@ -280,14 +285,14 @@ class BaseBackendTest:
     async def test_autoclose(self):
         async with self.init_session(autoclose=True) as session:
             mock_close = MagicMock(wraps=session.cache.close)
-            session.cache.close = mock_close
+            session.cache.close = mock_close  # type: ignore[method-assign]
             await session.get(httpbin('get'))
         mock_close.assert_called_once()
 
     async def test_autoclose__disabled(self):
         async with self.init_session(autoclose=False) as session:
             mock_close = MagicMock(wraps=session.cache.close)
-            session.cache.close = mock_close
+            session.cache.close = mock_close  # type: ignore[method-assign]
             await session.get(httpbin('get'))
         mock_close.assert_not_called()
         # explicitly call close after the test has completed
@@ -320,13 +325,13 @@ class BaseBackendTest:
         """
         async with self.init_session() as session:
             # first request shall populate the cache
-            response = await session.request('GET', httpbin('cache/0'))
+            response = cast(CachedResponse, await session.request('GET', httpbin('cache/0')))
 
             assert response.from_cache is False
             assert await session.cache.responses.size() == 1
 
             # second request shall come from the cache
-            response = await session.request('GET', httpbin('cache/0'))
+            response = cast(CachedResponse, await session.request('GET', httpbin('cache/0')))
 
             assert response.from_cache is True
             assert await session.cache.responses.size() == 1
@@ -334,7 +339,7 @@ class BaseBackendTest:
             # now disable the cache, the response should not come from the cache
             # but the cache should be unmodified afterward.
             async with session.disabled():
-                response = await session.request('GET', httpbin('cache/0'))
+                response = cast(CachedResponse, await session.request('GET', httpbin('cache/0')))
 
                 assert response.from_cache is False
                 assert await session.cache.responses.size() == 1
@@ -351,15 +356,15 @@ class BaseBackendTest:
             from unittest.mock import AsyncMock
 
             mock_refresh = AsyncMock(wraps=session._refresh_cached_response)
-            session._refresh_cached_response = mock_refresh
+            session._refresh_cached_response = mock_refresh  # type: ignore[method-assign]
 
-            response = await session.get(httpbin('cache'))
+            response = cast(CachedResponse, await session.get(httpbin('cache')))
             assert response.from_cache is False
             etag = response.headers['Etag']
             assert etag is not None
             mock_refresh.assert_not_awaited()
 
-            response = await session.get(httpbin('cache'), refresh=True)
+            response = cast(CachedResponse, await session.get(httpbin('cache'), refresh=True))
             assert response.from_cache is True
             assert etag == response.headers['Etag']
             mock_refresh.assert_awaited_once()
@@ -375,9 +380,9 @@ class BaseBackendTest:
             from unittest.mock import AsyncMock
 
             mock_refresh = AsyncMock(wraps=session._refresh_cached_response)
-            session._refresh_cached_response = mock_refresh
+            session._refresh_cached_response = mock_refresh  # type: ignore[method-assign]
 
-            response = await session.get(httpbin_custom('cache/1'))
+            response = cast(CachedResponse, await session.get(httpbin_custom('cache/1')))
             assert response.from_cache is False
             etag = response.headers['Etag']
             assert etag is not None
@@ -387,7 +392,9 @@ class BaseBackendTest:
             # after 2s the ETag should have been expired and the server should respond
             # with a 200 response rather than a 304.
 
-            response = await session.get(httpbin_custom('cache/1'), refresh=True)
+            response = cast(
+                CachedResponse, await session.get(httpbin_custom('cache/1'), refresh=True)
+            )
             assert response.from_cache is False
             assert etag != response.headers['Etag']
             mock_refresh.assert_awaited_once()
@@ -406,14 +413,14 @@ class BaseBackendTest:
             from unittest.mock import AsyncMock
 
             mock_refresh = AsyncMock(wraps=session._refresh_cached_response)
-            session._refresh_cached_response = mock_refresh
+            session._refresh_cached_response = mock_refresh  # type: ignore[method-assign]
 
-            response = await session.get(httpbin('cache/10'))
+            response = cast(CachedResponse, await session.get(httpbin('cache/10')))
             assert response.from_cache is False
             assert response.headers.get('Etag') is None
             mock_refresh.assert_not_awaited()
 
-            response = await session.get(httpbin('cache/10'), refresh=True)
+            response = cast(CachedResponse, await session.get(httpbin('cache/10'), refresh=True))
             assert response.from_cache is True
             assert response.headers.get('Etag') is None
             mock_refresh.assert_awaited_once()

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -4,7 +4,7 @@ import asyncio
 import pickle
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, Type, cast
+from typing import Any, AsyncIterator, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -33,8 +33,8 @@ pytestmark = pytest.mark.asyncio
 class BaseBackendTest:
     """Base class for testing cache backend classes"""
 
-    backend_class: Type[CacheBackend] = None  # type: ignore
-    init_kwargs: Dict[str, Any] = {}
+    backend_class: type[CacheBackend] = None  # type: ignore
+    init_kwargs: dict[str, Any] = {}
 
     @asynccontextmanager
     async def init_session(self, clear=True, **kwargs) -> AsyncIterator[CachedSession]:

--- a/test/integration/base_storage_test.py
+++ b/test/integration/base_storage_test.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, Type
+from typing import Any, AsyncIterator, TypeVar
 
 import pytest
 
@@ -11,25 +12,31 @@ pytestmark = pytest.mark.asyncio
 picklable_test_data = {'key_1': 'item_1', 'key_2': datetime(2021, 8, 14), 'key_3': 3.141592654}
 str_test_data = {f'key_{i}': f'item_{i}' for i in range(10)}
 
+BaseCacheT = TypeVar('BaseCacheT', bound=BaseCache)
+
 
 class BaseStorageTest:
     """Base class for testing cache storage dict-like interfaces"""
 
-    init_kwargs: Dict = {}
+    init_kwargs: dict = {}
     picklable: bool = False
-    storage_class: Type[BaseCache] = None  # type: ignore
-    test_data: Dict[str, Any] = picklable_test_data
+    test_data: dict[str, Any] = picklable_test_data
+    storage_class: type[BaseCache]
 
     @asynccontextmanager
-    async def init_cache(self, index=0, **kwargs) -> AsyncIterator[BaseCache]:
+    async def init_cache(
+        self, storage_class: type[BaseCacheT] | None = None, index=0, **kwargs
+    ) -> AsyncIterator[BaseCacheT]:
         self.test_data = picklable_test_data if self.picklable else str_test_data  # type: ignore
-        cache = self.storage_class(CACHE_NAME, f'table_{index}', **self.init_kwargs, **kwargs)
+        cache_class = storage_class or self.storage_class
+        assert cache_class
+        cache = cache_class(CACHE_NAME, f'table_{index}', **self.init_kwargs, **kwargs)
         await cache.clear()
-        yield cache
+        yield cache  # type: ignore[misc]
         await cache.close()
 
     async def test_write_read(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             # Test write(), contains(), and size()
             for k, v in self.test_data.items():
                 await cache.write(k, v)
@@ -41,12 +48,12 @@ class BaseStorageTest:
                 assert await cache.read(k) == v
 
     async def test_missing_key(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             assert await cache.contains('nonexistent_key') is False
             assert await cache.read('nonexistent_key') is None
 
     async def test_delete(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             await cache.write('do_not_delete', 'value')
             for k, v in self.test_data.items():
                 await cache.write(k, v)
@@ -58,7 +65,7 @@ class BaseStorageTest:
             assert await cache.read('do_not_delete') == 'value'
 
     async def test_bulk_delete(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             await cache.write('do_not_delete', 'value')
             for k, v in self.test_data.items():
                 await cache.write(k, v)
@@ -69,14 +76,14 @@ class BaseStorageTest:
                 assert await cache.contains(k) is False
 
     async def test_bulk_delete_ignores_nonexistent_keys(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             await cache.bulk_delete(self.test_data.keys())
 
     async def test_keys_values(self):
         test_data = {f'key_{i}': f'value_{i}' for i in range(20)}
 
         # test keys() and values()
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             assert [k async for k in cache.keys()] == []
             assert [v async for v in cache.values()] == []
 
@@ -87,7 +94,7 @@ class BaseStorageTest:
             assert sorted([v async for v in cache.values()]) == sorted(test_data.values())
 
     async def test_size(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             assert await cache.size() == 0
             for k, v in self.test_data.items():
                 await cache.write(k, v)
@@ -95,7 +102,7 @@ class BaseStorageTest:
             assert await cache.size() == len(self.test_data)
 
     async def test_clear(self):
-        async with self.init_cache() as cache:
+        async with self.init_cache() as cache:  # type: ignore[var-annotated]
             for k, v in self.test_data.items():
                 await cache.write(k, v)
 

--- a/test/integration/test_dynamodb.py
+++ b/test/integration/test_dynamodb.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from os import urandom
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -55,4 +55,4 @@ class TestDynamoDbCache(BaseStorageTest):
 
 class TestDynamoDBBackend(BaseBackendTest):
     backend_class = DynamoDBBackend
-    init_kwargs: Dict[str, Any] = {'create_if_not_exists': True, **AWS_OPTIONS}
+    init_kwargs: dict[str, Any] = {'create_if_not_exists': True, **AWS_OPTIONS}

--- a/test/integration/test_dynamodb.py
+++ b/test/integration/test_dynamodb.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from os import urandom
 from typing import Any, Dict
 
@@ -47,8 +48,8 @@ class TestDynamoDbCache(BaseStorageTest):
     async def test_write_oversized_item(self):
         """If an item exceeds DynamoDB's max item size, expect it to not be written to the cache"""
         data = urandom(MAX_ITEM_SIZE + 1)
-        async with self.init_cache() as cache:
-            cache.write('key', data)
+        async with self.init_cache(self.storage_class) as cache:
+            await cache.write('key', data)
             assert await cache.contains('key') is False
 
 

--- a/test/integration/test_filesystem.py
+++ b/test/integration/test_filesystem.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
 from contextlib import asynccontextmanager
 from os.path import isfile
 from shutil import rmtree
 from tempfile import gettempdir
 from typing import AsyncIterator
 
-from aiohttp_client_cache.backends.base import BaseCache
 from aiohttp_client_cache.backends.filesystem import FileBackend, FileCache
 from aiohttp_client_cache.session import CachedSession
 from test.conftest import CACHE_NAME
@@ -16,7 +16,7 @@ class TestFileCache(BaseStorageTest):
     picklable = True
 
     @asynccontextmanager
-    async def init_cache(self, index=0, **kwargs) -> AsyncIterator[BaseCache]:
+    async def init_cache(self, index=0, **kwargs) -> AsyncIterator[FileCache]:  # type: ignore[override]
         cache = self.storage_class(f'{CACHE_NAME}_{index}', use_temp=True, **kwargs)
         await cache.clear()
         yield cache
@@ -57,7 +57,7 @@ class TestFileBackend(BaseBackendTest):
             cache = session.cache
             assert isinstance(cache, FileBackend)
 
-            cache_dir = cache.responses.cache_dir
-            redirects_file = cache.redirects.filename
+            cache_dir = cache.responses.cache_dir  # type: ignore[attr-defined]
+            redirects_file = cache.redirects.filename  # type: ignore[attr-defined]
 
             assert redirects_file.startswith(cache_dir)

--- a/test/integration/test_memory.py
+++ b/test/integration/test_memory.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from aiohttp_client_cache.backends.base import CacheBackend, DictCache
 from test.conftest import httpbin
 from test.integration import BaseBackendTest, BaseStorageTest

--- a/test/integration/test_mongodb.py
+++ b/test/integration/test_mongodb.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 
 import pytest
@@ -29,14 +30,14 @@ class TestMongoDBCache(BaseStorageTest):
 
     async def test_connection_kwargs(self):
         loop = asyncio.get_running_loop()
-        async with self.init_cache(host='127.0.0.1', io_loop=loop) as cache:
+        async with self.init_cache(self.storage_class, host='127.0.0.1', io_loop=loop) as cache:
             assert cache.connection.address == ('127.0.0.1', 27017)
             assert cache.connection.io_loop is loop
 
     async def test_values_many(self):
         # If some entries are missing the "data" field for some reason, they
         # should not be returned with the results.
-        async with self.init_cache() as cache:
+        async with self.init_cache(self.storage_class) as cache:
             await cache.collection.insert_many({'data': f'value_{i}'} for i in range(10))
             await cache.collection.insert_many({'not_data': f'value_{i}'} for i in range(10))
             actual_results = [v async for v in cache.values()]

--- a/test/integration/test_redis.py
+++ b/test/integration/test_redis.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 
 import pytest
@@ -13,7 +14,7 @@ def is_db_running():
     async def get_db_info():
         client = await from_url(DEFAULT_ADDRESS)
         await client.info()
-        await client.aclose()
+        await client.aclose()  # type: ignore[attr-defined]
 
     try:
         asyncio.run(get_db_info())

--- a/test/integration/test_sqlite.py
+++ b/test/integration/test_sqlite.py
@@ -76,8 +76,8 @@ class TestSQLiteCache(BaseStorageTest):
             self.storage_class, index=1, fast_save=True
         ) as cache_1, self.init_cache(self.storage_class, index=2, fast_save=True) as cache_2:
             for i in range(1000):
-                await cache_1.write(str(i), str(i))
-                await cache_2.write(str(i), str(i))
+                await cache_1.write(i, i)  # type: ignore[arg-type]
+                await cache_2.write(i, i)  # type: ignore[arg-type]
 
             keys_1 = {k async for k in cache_1.keys()}
             keys_2 = {k async for k in cache_2.keys()}

--- a/test/unit/test_base_backend.py
+++ b/test/unit/test_base_backend.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pickle
 from unittest.mock import MagicMock, patch
 

--- a/test/unit/test_cache_control.py
+++ b/test/unit/test_cache_control.py
@@ -113,7 +113,7 @@ def test_init_from_settings(url, request_expire_after, expected_expiration):
         url=URL(url),
         request_expire_after=request_expire_after,
         session_expire_after=1,
-        urls_expire_after=urls_expire_after,
+        urls_expire_after=urls_expire_after,  # type: ignore[arg-type]
     )
     assert actions.expire_after == expected_expiration
 

--- a/test/unit/test_cache_keys.py
+++ b/test/unit/test_cache_keys.py
@@ -1,6 +1,8 @@
 """The cache_keys module is mostly covered indirectly via other tests.
 This just contains tests for some extra edge cases not covered elsewhere.
 """
+from __future__ import annotations
+
 from copy import copy
 
 import pytest

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from unittest import mock
 

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from http.cookies import SimpleCookie
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
There were some tricky places where I had two choices: a major refactoring or a "best effort" attempt to fix the type annotations.  

A simplified example to explain a challenge I had to solve in the "test/" folder:
```py
class BaseStorageTest:
    storage_class: type[BaseCache]  # This is tricky because we assign child classes that have more different attributes.
   
   def init_cache() -> BaseCache:  # This is tricky because this is a base class, but we always return a child class (Mongo, Redis, SQLite, etc.)
       yield self.storage_class


class TestMongoDBCache(BaseStorageTest):
    storage_class: MongoDBCache
        
    # Here we have many warnings about `BaseCache` has no attribute [...] because `init_cache` says it returns `BaseCache`.
    # For example, `BaseCache` has not attribute named `collection`.


class TestSQLiteCache(BaseStorageTest):
    storage_class: SQLiteCache

    # Here we have many warnings about `BaseCache` has no attribute [...] because `init_cache` says it returns `BaseCache`.
    # Type checkers do not know abut `SQLiteCache` *unique* attributes, so we have no IDE autocompletion and warnings from linters.
```

I was thinking about how to get IDE autocompletion and fix Mypy/Pyright warnings and come up with as small refactorings as possible, but better ideas are welcome.   
The workaround was to define that if we pass `type[SQLiteCache]` then we get `SQLiteCache`, etc.


Another tricky task was the fact that you return `-> CachedResponse | ClientResponse` but in the tests you always check  attributes of `CachedResponse` (e.g. `from_cache`). The simplest workaround was using `cast()` to tell IDE and a type checker that we work in the test with the `CachedResponse`.


---


CI for 3.11 and 3.12 failed with
```
cache/.venv/bin/python: bad interpreter: No such file or directory
Error: Process completed with exit code 126.
```
:heavy_check_mark:  Locally I successfully executed all tests for `3.8` and `3.12`.