### PR TITLE
 Remove usage of `datetime.utcnow()` (deprecated in python 3.12)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix compatibility with aiosqlite 0.20
+- Remove usage of `datetime.utcnow()` (deprecated in python 3.12)
 
 ## 0.11.0
 

--- a/aiohttp_client_cache/cache_control.py
+++ b/aiohttp_client_cache/cache_control.py
@@ -161,7 +161,7 @@ def get_expiration_datetime(expire_after: ExpirationTime) -> datetime | None:
     if not isinstance(expire_after, timedelta):
         assert isinstance(expire_after, (int, float))
         expire_after = timedelta(seconds=expire_after)
-    return datetime.utcnow() + expire_after
+    return utcnow() + expire_after
 
 
 def get_cache_directives(headers: Mapping) -> dict:
@@ -226,6 +226,7 @@ if sys.version_info >= (3, 10):
         except ValueError:
             logger.debug(f'Failed to parse timestamp: {value}')
             return None
+
 else:  # pragma: no cover
 
     def parse_http_date(value: str) -> datetime | None:
@@ -257,6 +258,14 @@ def convert_to_utc_naive(dt: datetime):
         dt.astimezone(timezone.utc)
         dt = dt.replace(tzinfo=None)
     return dt
+
+
+# TODO: This could be replaced with timezone-aware datetimes, but this will cause problems with
+# existing cache data. It would be best to do this at the same time as a release that includes
+# changes to request matching logic (i.e., new cache keys).
+def utcnow() -> datetime:
+    """Get the current time in UTC, as a timezone-naive datetime"""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 @singledispatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiohttp-client-cache"
-version="0.11.0"
+version="0.11.1"
 description = "Persistent cache for aiohttp requests"
 authors = ["Jordan Cook"]
 license = "MIT License"

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -1,21 +1,10 @@
 """Common tests to run for all backends"""
 
 from __future__ import annotations
+
 import asyncio
 import pickle
 from contextlib import asynccontextmanager
-from datetime import datetime
-from typing import Any, AsyncIterator, cast
-from unittest.mock import MagicMock
-from uuid import uuid4
-
-import pytest
-from async_timeout import timeout
-from itsdangerous.exc import BadSignature
-from itsdangerous.serializer import Serializer
-
-from aiohttp_client_cache import CacheBackend, CachedSession
-from aiohttp_client_cache.response import CachedResponse
 from test.conftest import (
     ALL_METHODS,
     CACHE_NAME,
@@ -27,6 +16,18 @@ from test.conftest import (
     httpbin,
     httpbin_custom,
 )
+from typing import Any, AsyncIterator, cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from async_timeout import timeout
+from itsdangerous.exc import BadSignature
+from itsdangerous.serializer import Serializer
+
+from aiohttp_client_cache import CacheBackend, CachedSession
+from aiohttp_client_cache.cache_control import utcnow
+from aiohttp_client_cache.response import CachedResponse
 
 pytestmark = pytest.mark.asyncio
 
@@ -218,7 +219,7 @@ class BaseBackendTest:
         """
         async with self.init_session() as session:
             session.cache.cache_control = True
-            now = datetime.utcnow()
+            now = utcnow()
             await session.get(httpbin('cache/60'), headers=request_headers)
             response = cast(
                 CachedResponse, await session.get(httpbin('cache/60'), headers=request_headers)

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -8,6 +8,7 @@ from aiohttp import ClientResponseError, web
 from multidict import MultiDictProxy
 from yarl import URL
 
+from aiohttp_client_cache.cache_control import utcnow
 from aiohttp_client_cache.response import CachedResponse, RequestInfo
 
 
@@ -62,17 +63,17 @@ async def test_basic_attrs(aiohttp_client):
     assert response._released is True
 
 
-@mock.patch('aiohttp_client_cache.response.datetime')
-async def test_is_expired(mock_datetime, aiohttp_client):
-    mock_datetime.utcnow = mock.Mock(return_value=datetime.utcnow())
-    expires = mock_datetime.utcnow() + timedelta(seconds=0.02)
+@mock.patch('aiohttp_client_cache.response.utcnow')
+async def test_is_expired(mock_utcnow, aiohttp_client):
+    mock_utcnow.return_value = utcnow()
+    expires = utcnow() + timedelta(seconds=0.02)
 
     response = await get_test_response(aiohttp_client, expires=expires)
 
     assert response.expires == expires
     assert response.is_expired is False
 
-    mock_datetime.utcnow.return_value += timedelta(0.02)
+    mock_utcnow.return_value += timedelta(0.02)
     assert response.is_expired is True
 
 


### PR DESCRIPTION
Fixes #237; related to #195

Note: a future improvement would be to start using timezone-aware datetime objects, but this will cause problems with existing cache data (can't compare timezone-aware and timezone-naive datetimes). It would be best to do this at the same time as a release that includes changes to request matching logic (i.e., new cache keys).