### PR TITLE
Fix error case in `CachedResponse.is_expired`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+# Unreleased
+
+- Fix `CachedResponse.is_expired` check to consider any errors as "expired"
+
 ## 0.11.1
 
 - Fix compatibility with aiosqlite 0.20

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -158,11 +158,11 @@ class CachedResponse(HeadersMixin):
     @property
     def is_expired(self) -> bool:
         """Determine if this cached response is expired"""
-        # If for any reason the expiration check fails, consider it expired and fetch a new response
         try:
             return self.expires is not None and utcnow() > self.expires
         except (AttributeError, TypeError, ValueError):
-            return False
+            # Consider it expired and fetch a new response
+            return True
 
     @property
     def links(self) -> MultiDictProxy:

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -79,7 +79,7 @@ async def test_is_expired(mock_utcnow, aiohttp_client):
 
 async def test_is_expired__invalid(aiohttp_client):
     response = await get_test_response(aiohttp_client, expires='asdf')
-    assert response.is_expired is False
+    assert response.is_expired is True
 
 
 async def test_content_disposition(aiohttp_client):


### PR DESCRIPTION
Thanks to @alessio-locatelli for pointing this out [here](https://github.com/requests-cache/aiohttp-client-cache/commit/2fa1b3926f78c145b826729333aa568cc4eac186#diff-b18bf159d5926d2ff91d8d8023250f2adf80ec7101a5e800a2055f16041ebbd4R138).