### PR TITLE
Fix `CachedResposnse.read()` and `ClientResponse.read()` consistency

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## (unreleased)
+
+- Fixed `CachedResponse.read()` to be consistent with `ClientResponse.read()` by allowing to call `read()` multiple times. (#289)
+
 ## 0.12.4 (2024-10-30)
 
 - Fixed a bug that allowed users to use `save_response()` and `from_client_response()` with an incorrect `expires` argument without throwing any warnings or errors.

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -69,7 +69,7 @@ class CachedResponse(HeadersMixin):
     status: int = attr.ib()
     url: URL = attr.ib(converter=URL)
     version: str = attr.ib()
-    _body: Any = attr.ib(default=b'')
+    _body: Any = attr.ib(default=None)
     _content: StreamReader | None = attr.ib(default=None)
     _links: LinkItems = attr.ib(factory=list)
     cookies: SimpleCookie = attr.ib(factory=SimpleCookie)
@@ -215,7 +215,9 @@ class CachedResponse(HeadersMixin):
 
     async def read(self) -> bytes:
         """Read response payload."""
-        return await self.content.read()
+        if self._body is None:
+            self._body = await self.content.read()
+        return self._body
 
     def reset(self):
         """Reset the stream reader to re-read a streamed response"""

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -215,8 +215,8 @@ class CachedResponse(HeadersMixin):
 
     async def read(self) -> bytes:
         """Read response payload."""
-        if self._body is None:
-            self._body = await self.content.read()
+        # We are ready to return the body because `read()`
+        # was called on a `CachedResponse` creation.
         return self._body
 
     def reset(self):


### PR DESCRIPTION
Closes https://github.com/requests-cache/aiohttp-client-cache/issues/289

## Inconsistency

- `ClientResponse` allows to call `read()` multiple times, returning a full content.

- `CachedResponse` allows to call `read()` multiple times, but silently returns nothing on further calls.

@JWCook  Would you mind sharing your viewpoint? If this behavior is intentional, I will update the test accordingly.  


---


**UPDATE 2024-10-30:**   
I do not know if anyone ever calls `read()` more than once, so you may want to keep this change unreleased for a while or create a pre-release. 