### PR TITLE
Avoid `can't compare offset-naive and offset-aware datetimes` in is_expired check for CachedResponse.

### DIFF
--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -159,7 +159,7 @@ class CachedResponse(HeadersMixin):
     def is_expired(self) -> bool:
         """Determine if this cached response is expired"""
         try:
-            return self.expires is not None and utcnow() > self.expires
+            return self.expires is not None and utcnow() > self.expires.replace(tzinfo=None)
         except (AttributeError, TypeError, ValueError):
             # Consider it expired and fetch a new response
             return True

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import timedelta, datetime, timezone
 from unittest import mock
 
 import pytest
@@ -80,6 +80,12 @@ async def test_is_expired(mock_utcnow, aiohttp_client):
 async def test_is_expired__invalid(aiohttp_client):
     response = await get_test_response(aiohttp_client, expires='asdf')
     assert response.is_expired is True
+
+
+async def test_is_expired__timezone_aware(aiohttp_client):
+    expires = datetime.now(timezone.utc) + timedelta(days=1)
+    response = await get_test_response(aiohttp_client, expires=expires)
+    assert response.is_expired is False
 
 
 async def test_content_disposition(aiohttp_client):


### PR DESCRIPTION
Currently, the following line:
`return self.expires is not None and utcnow() > self.expires`
fails on:
`can't compare offset-naive and offset-aware datetimes`
Because self.expires is timezone aware but utcnow() is not.

Because all errors are silenced as part of 0.12.0 release, we *always* return True, even if there's an exception.

Replacing the timezone in self.expires to None in this check will resolve the error, and the comparison will succeed.