### PR TITLE
Forbid wrong 'expires' values when low-level API is used that silently results in always expired responses

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## (unreleased)
+
+- Fixed a bug that allowed users to use `save_response()` and `from_client_response()` with an incorrect `expires` argument without throwing any warnings or errors.
+
 ## 0.12.3 (2024-10-04)
 
 - Revert some changes from `v0.12.0`, and add alternative fix for compatibility with aiohttp 3.10.6+


### PR DESCRIPTION
This PR closes https://github.com/requests-cache/aiohttp-client-cache/pull/286

As I explained on that page:
1. `convert_to_utc_naive()`  is not called for low-level API and it is a user responsibility to convert to a naive datetime. On our side we can raise an error.
2. `save_response()` and `from_client_response()` allow to save any random object as `expires`, including classes, functions, etc. and all these bad things work silently.

An alternative solution is moving `convert_to_utc_naive()` call inside the `from_client_response()`.

---

Notes:

```
        except (AttributeError, TypeError, ValueError):
```

1. `AttributeError` is impossible because `self.expires = None` is the default class attribute.
3. `TypeError` is handled now by verifying that we work with a naive datetime.
4. `ValueError` - I have no idea how you can get it when you compare two `datetime` objects. Perhaps an old leftover.


Breaking changes:

There are no breaking changes. 
 Users who used the low-level functions directly (`save_response()` and `from_client_response()`) incorrectly by passing a wrong `expires` value will get an error. This is expected because so far, with the old code, they cache never worked correctly. 


---

The commit history is clean and tidy, so do not squash the commits.