### PR TITLE
Show a warning on a cache access when a `CachedSession` context manager has been exited

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## (unreleased)
+
+- Now a warning is raised when a cache backend is accessed after disconnecting (after exiting the `CachedSession` context manager). (#241)
+
 ## 0.12.4 (2024-10-30)
 
 - Fixed a bug that allowed users to use `save_response()` and `from_client_response()` with an incorrect `expires` argument without throwing any warnings or errors.

--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -296,6 +296,7 @@ class BaseCache(metaclass=ABCMeta):
     ):
         super().__init__()
         self._serializer = serializer or self._get_serializer(secret_key, salt)
+        self._closed = False
 
     def serialize(self, item: ResponseOrKey = None) -> bytes | None:
         """Serialize a URL or response into bytes"""


### PR DESCRIPTION
Closes https://github.com/requests-cache/aiohttp-client-cache/issues/241

## MRE

```py
import asyncio
from aiohttp_client_cache import CachedSession, SQLiteBackend

cache = SQLiteBackend(cache_name="./test_cache.sqlite")

async def task(n: int):
    url = f"https://httpbin.org/ip?count={n}"
    async with CachedSession(cache=cache) as session:
        return await session.get(url, ssl=False)
    
async def tasks(arr: list):
    tasks = [task(i) for i in arr]
    return await asyncio.gather(*tasks)


asyncio.run(tasks(list(range(10))))
```

### 1st run (there is no cache file yet)

We can see the warning inside `get_connection()` **after** the `yield`:

```py
❯ python .gather_sessions.py
/usr/lib64/python3.13/contextlib.py:221: UserWarning: Cache access after closing the `Cachedsession` context manager is discouraged and can be forbidden in the future to prevent errors related to a closed database connection.
  await anext(self.gen)
Traceback (most recent call last):
[...]
sqlite3.ProgrammingError: Cannot operate on a closed database.
```

### 2nd run (a cache file already exists)

We can see the warning inside the `def read()`:

```py
/usr/lib64/python3.13/contextlib.py:221: UserWarning: Cache access after closing the `Cachedsession` context manager is discouraged and can be forbidden in the future to prevent errors related to a closed database connection.
  await anext(self.gen)
Traceback (most recent call last):
[...]
sqlite3.ProgrammingError: Cannot operate on a closed database.
```

## Notes

Not related to this PR and the mentioned issue, but Redis and MongoDB must have the `def close()` method too because the connections must be closed.
