### PR TITLE
Fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.27.3
+    hooks:
+      - id: typos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ To generate a coverage report:
 nox -e cov
 ```
 
-See `nox --list` for a ful list of available commands.
+See `nox --list` for a full list of available commands.
 
 ### Integration Test Containers
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -156,7 +156,7 @@
 
 ## 0.4.3 (2021-07-27)
 
-- Fix bug in which reponse header `Expires` was used for cache expiration even with `cache_control=False`
+- Fix bug in which response header `Expires` was used for cache expiration even with `cache_control=False`
 - Fix bug in which HTTP dates parsed from response headers weren't converted to UTC
 - Add handling for invalid timestamps in `CachedResponse.is_expired`
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["CONTRIBUTORS.md"]

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@
 
 :::{warning}
 The python `pickle` module has [known security vulnerabilities](https://docs.python.org/3/library/pickle.html),
-potentially leading to code execution when deserialzing data.
+potentially leading to code execution when deserializing data.
 :::
 
 This means it should only be used to deserialize data that you trust hasn't been tampered with.


### PR DESCRIPTION
There is no noticeable linting overhead because the linter is written in Rust and is extremely fast even on huge codebases. 
