### PR TITLE
Share aiosqlite connection and async lock used by SQLite backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v1.16.0
     hooks:
       - id: mypy
+        files: aiohttp_client_cache
         additional_dependencies: [attrs, aiohttp, types-aiofiles, types-redis]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## Unreleased
+
+- Fixed a race condition in SQLite backend that could lead to `sqlite3.OperationalError: database is locked` errors
+
 ## 0.13.0 (2025-04-08)
 
 - Fixed `CachedResponse.read()` to be consistent with `ClientResponse.read()` by allowing to call `read()` multiple times. (#289)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ show_error_codes = true
 show_column_numbers = true
 check_untyped_defs=true
 pretty = true
-exclude = "dist|build"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -7,7 +7,7 @@ import pickle
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -365,8 +365,6 @@ class BaseBackendTest:
         async with self.init_session() as session:
             # mock the _refresh_cached_response method to verify
             # that a conditional request is being made
-            from unittest.mock import AsyncMock
-
             mock_refresh = AsyncMock(wraps=session._refresh_cached_response)
             session._refresh_cached_response = mock_refresh  # type: ignore[method-assign]
 


### PR DESCRIPTION
(probably) fixes #330.

The main change is to set a single (unconnected) `aiosqlite.Connection` object on both `responses` and `redirects` during init. When the first request is made, `SQLiteBackend.responses.get_connection()` will open the connection.

This depends on the fact that `aiosqlite.connect()` isn't actually a coroutine, but a wrapper that returns a `Thread` subclass that also implements an [`__await__`](https://github.com/omnilib/aiosqlite/blob/main/aiosqlite/core.py#L138-L140) method that starts the thread. There are some more details in the comments. This requires checking some of aiosqlite's internal attributes, which I don't love, but at the moment it seems like the least messy option.

Let me know if anyone has suggestions for better ways to go about it!
