### PR TITLE
Type hinting `__aenter__` with `Self`

### DIFF
--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from collections.abc import Mapping
 from datetime import datetime
 from functools import singledispatch
@@ -22,6 +23,11 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
 from aiohttp_client_cache.cache_control import utcnow
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 # CachedResponse attributes to not copy directly from ClientResponse
 EXCLUDE_ATTRS = {
@@ -259,7 +265,7 @@ class CachedResponse(HeadersMixin):
     def connection(self):
         return None
 
-    async def __aenter__(self) -> CachedResponse:
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(self, *exc: Any) -> None:

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -42,6 +42,12 @@ else:
             pass
 
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
 @lru_cache(maxsize=16384)
 def _get_lock(_: int, __: str) -> Lock:
     return Lock()
@@ -245,5 +251,5 @@ with warnings.catch_warnings():
                 options. If not provided, an in-memory cache will be used.
         """
 
-        async def __aenter__(self) -> CachedSession:
+        async def __aenter__(self) -> Self:
             return self

--- a/poetry.lock
+++ b/poetry.lock
@@ -3111,4 +3111,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "23abe96a533d9b247f50286290b21d54b3ad815e7f46df2983d8d34255241e68"
+content-hash = "84bf07810d338cdcf441e82e73016f3cee69a887cbd3acfba66ede005925b7db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ python          = ">=3.9"
 aiohttp         = "^3.8"
 attrs           = ">=21.2"
 itsdangerous    = ">=2.0"
+typing-extensions = {python="<=3.10", version=">=4"}  # Pin v4 for Self addition
 url-normalize   = "^2.2"
 
 # Optional backend dependencies


### PR DESCRIPTION
Adds `typing-extensions>=4` for Python before 3.11 for the `Self` type, too.

Closes https://github.com/requests-cache/aiohttp-client-cache/issues/352