### PR TITLE
Fix session include_headers

### DIFF
--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -82,6 +82,8 @@ class CacheMixin(MIXIN_BASE):
     ) -> CachedResponse:
         """Wrapper around :py:meth:`.SessionClient._request` that adds caching"""
         # Attempt to fetch cached response
+        headers = self._prepare_headers(kwargs.get('headers', None))
+        kwargs['headers'] = headers
         key = self.cache.create_key(method, str_or_url, **kwargs)
         actions = self.cache.create_cache_actions(
             key, str_or_url, expire_after=expire_after, refresh=refresh, **kwargs

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -189,3 +189,17 @@ async def test_mixin(mock_request):
         await session.get('http://test.url')
 
     assert mock_request.called is False
+
+
+@patch.object(ClientSession, '_request', return_value=FakeCachedResponse)
+async def test_session__cache_include_headers(mock_request):
+    async with CachedSession(cache=CacheBackend(include_headers=True)) as session:
+        await session.get('https://test.com')
+
+        assert mock_request.called is True
+        mock_request.called = False
+
+        session.headers.update({'key': 'value'})
+        await session.get('https://test.com')
+
+        assert mock_request.called is True


### PR DESCRIPTION
Adds support for session headers when using cache include_headers parameter.
Also implements unit tests.