### PR TITLE
fix: use correct `uv` command

### DIFF
--- a/test/server/Dockerfile
+++ b/test/server/Dockerfile
@@ -13,7 +13,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
 # Install dependencies
-RUN uv sync --extra test-server --no-dev
+RUN uv sync --group test-server --no-dev
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups

This used to fail with

```
STEP 7/11: RUN uv sync --extra test-server --no-dev
Using CPython 3.13.9 interpreter at: /usr/local/bin/python3
Creating virtual environment at: .venv
Resolved 119 packages in 0.83ms
error: Extra `test-server` is not defined in the project's `optional-dependencies` table
Error: building at STEP "RUN uv sync --extra test-server --no-dev": while running runtime: exit status 2
ERROR:podman_compose:Build command failed
Error: executing /usr/sbin/podman-compose up httpbin-custom: exit status 2
```