### PR TITLE
fix(type-annotations): add missing `_ExpandedRequestOptions.refresh`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## Not released
+
+- Added `_ExpandedRequestOptions.refresh` to satisfy Pyright type checking.
+
 ## 0.14.3 (2026-01-07)
 
 - Fix compatibility with aiosqlite 0.22.1+

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     class _ExpandedRequestOptions(_RequestOptions, total=False):
         expire_after: ExpirationTime
+        refresh: bool
 
     MIXIN_BASE = ClientSession
 


### PR DESCRIPTION
Closes https://github.com/requests-cache/aiohttp-client-cache/issues/395

Only Pyright complained about this attribute. `mypy` and `ty` did not complain.