### PR TITLE
Test updates: compatibility fix for aiohttp 3.14, and replace httpbin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
           - '3.10'
           - '3.9'
     services:
-      nginx:
-        image: kennethreitz/httpbin
+      httpbin:
+        image: mccutchen/go-httpbin
         ports:
-          - 8080:80
+          - 8080:8080
 
     steps:
       # Install dependencies, with caching

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
 # Containers needed to test all backend services locally
 services:
   httpbin:
-    image: kennethreitz/httpbin
+    image: mccutchen/go-httpbin
     container_name: httpbin
     ports:
-      # Use an unprivileged port to support running the Docker daemon as a non-root user (Rootless mode).
-      # See https://docs.docker.com/engine/security/rootless/#networking-errors
-      - ${HTTPBIN_CUSTOM_PORT:-8080}:80
+      - ${HTTPBIN_CUSTOM_PORT:-8080}:8080
 
   httpbin-custom:
     container_name: httpbin-custom

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,6 @@ ALL_METHODS = ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
 CACHE_NAME = 'pytest_cache'
 HTTPBIN_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 HTTPBIN_FORMATS = [
-    'brotli',
     'deflate',
     'deny',
     'encoding/utf8',

--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -291,7 +291,7 @@ class BaseBackendTest:
             session.cookie_jar.clear()
             await session.get(httpbin('cookies/set?test_cookie=value'))
 
-        cookies = session.cookie_jar.filter_cookies(httpbin())
+        cookies = session.cookie_jar.filter_cookies(httpbin('cookies'))
         assert cookies['test_cookie'].value == 'value'
 
     async def test_autoclose(self):

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from http.cookies import SimpleCookie
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from aiohttp import ClientResponse
 from yarl import URL
@@ -13,7 +14,8 @@ from aiohttp_client_cache.session import CachedSession, CacheMixin, ClientSessio
 
 pytestmark = [pytest.mark.asyncio]
 
-
+aiohttp_314 = tuple(int(x) for x in aiohttp.__version__.split('.')[:2]) >= (3, 14)
+extra_args = {'stream_writer': MagicMock()} if aiohttp_314 else {}
 FakeCachedResponse = CachedResponse(method='GET', reason='OK', status=200, url='url', version='1.1')
 FakeClientResponse = ClientResponse(
     method='GET',
@@ -26,6 +28,7 @@ FakeClientResponse = ClientResponse(
     # loop=asyncio.get_event_loop(),
     loop=MagicMock(),
     session=None,  # type: ignore[arg-type]
+    **extra_args,  # type: ignore[arg-type]
 )
 
 


### PR DESCRIPTION
* Update `FakeClientResponse` test fixture for compatibility with aiohttp 3.14, which added a new `stream_writer` arg for `ClientResponse`. 
* Replace [httpbin](https://github.com/postmanlabs/httpbin) (last updated 8 years ago) with [go-httpbin](https://github.com/mccutchen/go-httpbin) (actively maintained)
  * This requires dropping a test for brotli compression (no golang stdlib support for this) 