### PR TITLE
chore: add ruff-extra-rules linter/formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 .mypy_cache/
 .tox
 test-reports/
+.cache
 
 # Sphinx
 docs/_build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,9 @@ repos:
     rev: v1.47.2
     hooks:
       - id: typos
+  - repo: https://github.com/alessio-locatelli/ruff-extra-rules
+    rev: v0.2.2
+    hooks:
+      - id: ruff-extra-rules
+      - id: ruff-extra-rules-ty
+        additional_dependencies: [ty]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,5 +147,15 @@ known-first-party = ['test']
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120
 
+[tool.ruff-extra-rules]
+fix = true
+
+[tool.ruff-extra-rules.per-file-ignores]
+# Keeping the library interface (regardless of whether it is a public or
+# private function) is more important than renaming a function for a negligible
+# clarity improvement. However, this can be done in the next major release.
+"aiohttp_client_cache/*" = ["validate-function-name"]
+"examples/*" = ["validate-function-name"]
+
 [tool.typos]
 files.extend-exclude = ["CONTRIBUTORS.md"]


### PR DESCRIPTION
**Background:** During code review, I've noticed that I repeat the same feedback for both coding agents and human developers. Some of these rules are either not yet implemented in linters or still under development, so I decided to fill this gap.

I'm flexible on the outcome:

- This is rejected with a reason
- This is kept as an addition to ruff

---

If there will be a green light on this, I would like to submit an equivalent PR for https://github.com/requests-cache/requests-cache/